### PR TITLE
feat: 28 new cursors, cursor redesigns, hover performance boost, and SEO upgrades

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -39,7 +39,8 @@
         "prettier": "^3.7.4",
         "tailwindcss": "^4",
         "tw-animate-css": "^1.4.0",
-        "typescript": "^5"
+        "typescript": "^5",
+        "vitest": "^4.1.10"
       }
     },
     "node_modules/@alloc/quick-lru": {
@@ -1245,6 +1246,16 @@
         "node": ">=12.4.0"
       }
     },
+    "node_modules/@oxc-project/types": {
+      "version": "0.143.0",
+      "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.143.0.tgz",
+      "integrity": "sha512-u6JZdLBTLotrNC9Vd6vPssINdzcCzleKAH6EJKImQb7GtYvX5keN2dxkoK44stCc4tffE6QQRtZTXVSzsLUlWA==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/Boshen"
+      }
+    },
     "node_modules/@pkgr/core": {
       "version": "0.2.9",
       "resolved": "https://registry.npmjs.org/@pkgr/core/-/core-0.2.9.tgz",
@@ -1808,6 +1819,251 @@
         }
       }
     },
+    "node_modules/@rolldown/binding-android-arm64": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.2.3.tgz",
+      "integrity": "sha512-zrJtHDcaZJ1Fp7xf4hNl+7seH9Cn/N5TwLYkhgXREtBwAd/jaqW3uqeHxpDugJLVICWg4eW44kOQEGJ1r6jCGw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-darwin-arm64": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.2.3.tgz",
+      "integrity": "sha512-ieIiibVCp0tX7TLu2cafoNPv8wJyYi01ekXpbf8q2j7F4rGAhhXb/eQh7ge9DRBY78GwmRQtvjZDux7EDbA8kA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-darwin-x64": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.2.3.tgz",
+      "integrity": "sha512-Zh9tCon19eDXJoihx0rqKhMUlMYqzwj3aPsSuHmI4RWZh62dWUL+DJN4C5YQya5TcQBJU/Fe8+rY0jhXTQITqA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-freebsd-x64": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.2.3.tgz",
+      "integrity": "sha512-nGbJWewA1wrXXZiQhjAT5rhibGfns5ZNkDVqxsO6zJ3f3YvpoDNNmGMSbbhLuXKjNScaBJVOAboztAWVespQMg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-arm-gnueabihf": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.2.3.tgz",
+      "integrity": "sha512-QNniJr5Kml0kDEB98jiDOJjXNroxIIi0IXIbdYzY26Xt1pVbeP62+KnoIZLwirOymX/0jDk/2gI/bNUv7A7OIw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-arm64-gnu": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.2.3.tgz",
+      "integrity": "sha512-TkqEAcmmvH3I/q4114NB4RVt6241Dao48pF45uLcFGrwAaIn0iITgTAKP/dLjbN0R4buJjGb91+UHSoFmpgIWw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-arm64-musl": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.2.3.tgz",
+      "integrity": "sha512-NHqjnxpsndf4MPymxteFAWHHfkTL8HjWh1KB7z23ofZ6QO2euONuxDXjat69dKZRALnGypg8k8SsK8vZJoXv1Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-ppc64-gnu": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.2.3.tgz",
+      "integrity": "sha512-6tbrbwfz5GB9DQ4Jwo6hy9v+vR31xZlvzZ6n5Xut6Hhx5PvrA9q/HsK8KMaYQp063iqZGXwNvZtYNLD7EM/x0w==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-s390x-gnu": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.2.3.tgz",
+      "integrity": "sha512-oyuXxXmoZHjXC917IAPFAAv4wWAa0cM9afk8nx1+9/jNNOX1uPf8yDA6p7G0RypOfw/X0PQt5IfoquY1um+zSg==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-x64-gnu": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.2.3.tgz",
+      "integrity": "sha512-TytMwF2KVGqP2tgd0I1OY0PAv78dZRAYcF5ssDzjM34SUXCED3uXvSd5+lHoC0bTD6eEdFz7LdQNCO1y0oVk9w==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-x64-musl": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.2.3.tgz",
+      "integrity": "sha512-/E9m3qstrJFVPoULV25mVQblSNExY2+kBsYe4sy0Tn0yOOgJ8wZbZt3KnRbF/XeU2Gl1STKUQnDNTqhIE5MD4A==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-openharmony-arm64": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.2.3.tgz",
+      "integrity": "sha512-Kr0OcsoQI816i6HOl3vFHpd1K0eZyh76zgfj4c1nTyaTsd5r2Mj1lwM4R90y/qaCfmTn9eHy0SKwi98eitRxug==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-win32-arm64-msvc": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.2.3.tgz",
+      "integrity": "sha512-hOtMwTqnME+/gJcH/PCZ0wn0zPUjiWOgkHpxbSJpfGKMezHltx1S7/k1SitzVa7Ww2cqrDDaFbZEhcJZO8o+Jw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-win32-x64-msvc": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.2.3.tgz",
+      "integrity": "sha512-ekcqMMkI2PlhYnfzQnB/cEdYUVVJViWvoUyLrbzgDoi3Snfc1mVBwdnc306ufA5ejy8JSPjT2RlW1nQSjW7efg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/pluginutils": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.1.tgz",
+      "integrity": "sha512-2j9bGt5Jh8hj+vPtgzPtl72j0yRxHAyumoo6TNfAjsLB04UtpSvPbPcDcBMxz7n+9CYB0c1GxQFxYRg2jimqGw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@rtsao/scc": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@rtsao/scc/-/scc-1.1.0.tgz",
@@ -1880,6 +2136,13 @@
       "version": "10.0.2",
       "resolved": "https://registry.npmjs.org/@shikijs/vscode-textmate/-/vscode-textmate-10.0.2.tgz",
       "integrity": "sha512-83yeghZ2xxin3Nj8z1NMd/NCuca+gsYXswywDy5bHvwlWL8tpTQmzGeUuHd9FC3E/SBEMvzJRwWEOz5gGes9Qg==",
+      "license": "MIT"
+    },
+    "node_modules/@standard-schema/spec": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
+      "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/@swc/helpers": {
@@ -2172,6 +2435,24 @@
       "dependencies": {
         "tslib": "^2.4.0"
       }
+    },
+    "node_modules/@types/chai": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
+      "integrity": "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/deep-eql": "*",
+        "assertion-error": "^2.0.1"
+      }
+    },
+    "node_modules/@types/deep-eql": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
+      "integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@types/estree": {
       "version": "1.0.8",
@@ -2830,6 +3111,119 @@
         }
       }
     },
+    "node_modules/@vitest/expect": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.10.tgz",
+      "integrity": "sha512-YsCn+qAk1GWjQOWFEsEcL2gNQ0zmVmQu3T03qP6UyjhtmdtwtbuI+DASn/7iQB3HGTXkdBwGddzxPlmiql5vlA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@standard-schema/spec": "^1.1.0",
+        "@types/chai": "^5.2.2",
+        "@vitest/spy": "4.1.10",
+        "@vitest/utils": "4.1.10",
+        "chai": "^6.2.2",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/mocker": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.10.tgz",
+      "integrity": "sha512-v0xaezt+DKEmKfaxg133ldzADrwLGd7Ze1MfQQTYfvs8OqZIwbxyxaYURivwV7sWy5fqn3rH5uOrSp07bp44Ow==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "4.1.10",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.21"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/pretty-format": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.10.tgz",
+      "integrity": "sha512-W1HsjSH4MXQ9YfmmhLAoIYf1HRfekQCGngeIgcei6MP5QQGWUe0gkopdZQaVCFO+JDJMrAJGwa5pRpNpvy4P8Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.1.10.tgz",
+      "integrity": "sha512-IKI6kpIH+LmpROplyLwBBaCfMgOZOMsygVa6BARD6ahA04VRuJSa6OaVG7kRvSEMD870Vd91rSSw0eegtWyLGg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "4.1.10",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.1.10.tgz",
+      "integrity": "sha512-xRkfOT1qpTAi/Ti4Y1LtfRc3kEuqxGw59eN2jN9pRWMtS/XDevekhcFSqvQqjUNGksfjMJu3Y+oJ+4Ypn2OaJw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.10",
+        "@vitest/utils": "4.1.10",
+        "magic-string": "^0.30.21",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/spy": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.10.tgz",
+      "integrity": "sha512-PLf/Ugvoq5wO/b4rwYCR1h2PSIdXz7wnkQFMiUpLdtM7l6pqVFcQIBEHyT1+l+cj7mNwAfZHzqXqDyjvOuwbDw==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.10.tgz",
+      "integrity": "sha512-fy9am/HWxbaGt/Sawrp90vt6Y6jQwf1RX77cz3uwoJwJVMli/e1IEwRPnMNJ7vKfPTwo0diXifkpPvwH9v7nGA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.10",
+        "convert-source-map": "^2.0.0",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
     "node_modules/acorn": {
       "version": "8.15.0",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.15.0.tgz",
@@ -3075,6 +3469,16 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/assertion-error": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/ast-types-flow": {
       "version": "0.0.8",
       "resolved": "https://registry.npmjs.org/ast-types-flow/-/ast-types-flow-0.0.8.tgz",
@@ -3300,6 +3704,16 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/chai": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-6.2.2.tgz",
+      "integrity": "sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/chalk": {
@@ -3764,6 +4178,13 @@
       "engines": {
         "node": ">= 0.4"
       }
+    },
+    "node_modules/es-module-lexer": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.3.1.tgz",
+      "integrity": "sha512-shc1dbU90Yl/xq1QrC7QRtfcwURZuVRfPhZbDoldJ1cn1gzDvBaBWlv0eFolj5+0znnPJz5TXLxsN77X/12KTA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/es-object-atoms": {
       "version": "1.1.1",
@@ -4309,6 +4730,16 @@
         "node": ">=4.0"
       }
     },
+    "node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
     "node_modules/esutils": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
@@ -4317,6 +4748,16 @@
       "license": "BSD-2-Clause",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/expect-type": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.4.0.tgz",
+      "integrity": "sha512-KfYbmpRm0VbLjEvVa9yGwCi9GI34xvi7A/HXYWQO65CSD2u3MczUJSuwXKFIxlGsgBQizV9q5J9NHj4VG0n+pA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.0.0"
       }
     },
     "node_modules/fast-deep-equal": {
@@ -4492,6 +4933,21 @@
         "react-dom": {
           "optional": true
         }
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
     "node_modules/function-bind": {
@@ -6006,9 +6462,9 @@
       "license": "MIT"
     },
     "node_modules/nanoid": {
-      "version": "3.3.11",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
-      "integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
+      "version": "3.3.18",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.18.tgz",
+      "integrity": "sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==",
       "funding": [
         {
           "type": "github",
@@ -6267,6 +6723,20 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/obug": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/obug/-/obug-2.1.4.tgz",
+      "integrity": "sha512-4a+OsYv9UktOJKE+l1A4OufDgdRF9PifWj+tJnHURo/P+WOxpG4GzUFL9qCalmWauao6ogiG+QvnCovwPoyAWA==",
+      "dev": true,
+      "funding": [
+        "https://github.com/sponsors/sxzz",
+        "https://opencollective.com/debug"
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.20.0"
+      }
+    },
     "node_modules/oniguruma-parser": {
       "version": "0.12.1",
       "resolved": "https://registry.npmjs.org/oniguruma-parser/-/oniguruma-parser-0.12.1.tgz",
@@ -6392,6 +6862,13 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/pathe": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/picocolors": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
@@ -6422,9 +6899,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.6",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.6.tgz",
-      "integrity": "sha512-3Ybi1tAuwAP9s0r1UQ2J4n5Y0G05bJkpUIO0/bI9MhwmD70S5aTWbXGBwxHrelT+XM1k6dM0pk+SwNkpTRN7Pg==",
+      "version": "8.5.26",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.26.tgz",
+      "integrity": "sha512-u82N74LFzG8ca+dD8puPnplTXoGH4fTPpVGuIbt36G3qvNlkvfD0lEAZSxaly3KX8TS/L1A1gsCEmvKmBcVbkQ==",
       "dev": true,
       "funding": [
         {
@@ -6442,7 +6919,7 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "nanoid": "^3.3.11",
+        "nanoid": "^3.3.17",
         "picocolors": "^1.1.1",
         "source-map-js": "^1.2.1"
       },
@@ -6769,6 +7246,39 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/rolldown": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.2.3.tgz",
+      "integrity": "sha512-rn9wpmxplLf7NLNyCk9FyWh3FM43DbY8jOzCdEPzH7uflhTftRbCEpqi6Ly2osgoU8OwObtmavMbWLaWy4LX7A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@oxc-project/types": "=0.143.0",
+        "@rolldown/pluginutils": "^1.0.0"
+      },
+      "bin": {
+        "rolldown": "bin/cli.mjs"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "optionalDependencies": {
+        "@rolldown/binding-android-arm64": "1.2.3",
+        "@rolldown/binding-darwin-arm64": "1.2.3",
+        "@rolldown/binding-darwin-x64": "1.2.3",
+        "@rolldown/binding-freebsd-x64": "1.2.3",
+        "@rolldown/binding-linux-arm-gnueabihf": "1.2.3",
+        "@rolldown/binding-linux-arm64-gnu": "1.2.3",
+        "@rolldown/binding-linux-arm64-musl": "1.2.3",
+        "@rolldown/binding-linux-ppc64-gnu": "1.2.3",
+        "@rolldown/binding-linux-s390x-gnu": "1.2.3",
+        "@rolldown/binding-linux-x64-gnu": "1.2.3",
+        "@rolldown/binding-linux-x64-musl": "1.2.3",
+        "@rolldown/binding-openharmony-arm64": "1.2.3",
+        "@rolldown/binding-win32-arm64-msvc": "1.2.3",
+        "@rolldown/binding-win32-x64-msvc": "1.2.3"
+      }
+    },
     "node_modules/run-parallel": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.2.0.tgz",
@@ -7086,6 +7596,13 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/source-map-js": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
@@ -7109,6 +7626,20 @@
       "version": "0.0.5",
       "resolved": "https://registry.npmjs.org/stable-hash/-/stable-hash-0.0.5.tgz",
       "integrity": "sha512-+L3ccpzibovGXFK+Ap/f8LOS0ahMrHTf3xu7mMLSpEGU0EO9ucaysSylKo9eRDFNhWve/y275iPmIZ4z39a9iA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/std-env": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-4.2.0.tgz",
+      "integrity": "sha512-oCUKSupKTHX53EyjDtuZQ64pjLJ6yYCtpmEw0goYxtjG9KpbRe8KAsl2tBUGU9DyMcJ0RwJ8GqJAFzMXcXW1Rw==",
       "dev": true,
       "license": "MIT"
     },
@@ -7380,15 +7911,32 @@
         "url": "https://opencollective.com/webpack"
       }
     },
+    "node_modules/tinybench": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinyexec": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.3.0.tgz",
+      "integrity": "sha512-QKAl9m8gWWGHV8jZcPeym6j+XULi6tOf1mT83WYJ4Lk2ytW/uwAWkrP0uFsdoYMdueVJ0qs26wZ+23xeB4ibNQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/tinyglobby": {
-      "version": "0.2.15",
-      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.15.tgz",
-      "integrity": "sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ==",
+      "version": "0.2.17",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.17.tgz",
+      "integrity": "sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "fdir": "^6.5.0",
-        "picomatch": "^4.0.3"
+        "picomatch": "^4.0.4"
       },
       "engines": {
         "node": ">=12.0.0"
@@ -7416,9 +7964,9 @@
       }
     },
     "node_modules/tinyglobby/node_modules/picomatch": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
-      "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.5.tgz",
+      "integrity": "sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -7426,6 +7974,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/tinyrainbow": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-3.1.1.tgz",
+      "integrity": "sha512-yau8yJdTt989Mm0Bd/236QnzEiPf2xLLTqUZRUJOo/3CB078LSwzei343DgtJVmfJKJE3TMINY1u42SQsP6mXw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
       }
     },
     "node_modules/to-regex-range": {
@@ -7876,6 +8434,461 @@
         "url": "https://opencollective.com/unified"
       }
     },
+    "node_modules/vite": {
+      "version": "8.2.1",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-8.2.1.tgz",
+      "integrity": "sha512-EU/eS7BH3XROHh2YnBefjM6DBKA6ZeMZEYQbj7NLWg5wHYlhB8B/Mayd5XsgWq+NFYccDOTemRpdETWR6Ka/lw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "lightningcss": "^1.33.0",
+        "picomatch": "^4.0.5",
+        "postcss": "^8.5.25",
+        "rolldown": "~1.2.1",
+        "tinyglobby": "^0.2.17"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      },
+      "peerDependencies": {
+        "@types/node": "^20.19.0 || >=22.12.0",
+        "@vitejs/devtools": "^0.4.0",
+        "esbuild": "^0.27.0 || ^0.28.0",
+        "jiti": ">=1.21.0",
+        "less": "^4.0.0",
+        "sass": "^1.70.0",
+        "sass-embedded": "^1.70.0",
+        "stylus": ">=0.54.8",
+        "sugarss": "^5.0.0",
+        "terser": "^5.16.0",
+        "tsx": "^4.8.1",
+        "yaml": "^2.4.2"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "@vitejs/devtools": {
+          "optional": true
+        },
+        "esbuild": {
+          "optional": true
+        },
+        "jiti": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "sass-embedded": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        },
+        "tsx": {
+          "optional": true
+        },
+        "yaml": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vite/node_modules/lightningcss": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss/-/lightningcss-1.33.0.tgz",
+      "integrity": "sha512-WkUDrojuJs0xkgGf2udWxa3yGBRxPtxUkB79i6aCZLRgc7PM8fZe9TosfPDcvEpQZbuFASnHYmRLBLUbmLOIIA==",
+      "dev": true,
+      "license": "MPL-2.0",
+      "dependencies": {
+        "detect-libc": "^2.0.3"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      },
+      "optionalDependencies": {
+        "lightningcss-android-arm64": "1.33.0",
+        "lightningcss-darwin-arm64": "1.33.0",
+        "lightningcss-darwin-x64": "1.33.0",
+        "lightningcss-freebsd-x64": "1.33.0",
+        "lightningcss-linux-arm-gnueabihf": "1.33.0",
+        "lightningcss-linux-arm64-gnu": "1.33.0",
+        "lightningcss-linux-arm64-musl": "1.33.0",
+        "lightningcss-linux-x64-gnu": "1.33.0",
+        "lightningcss-linux-x64-musl": "1.33.0",
+        "lightningcss-win32-arm64-msvc": "1.33.0",
+        "lightningcss-win32-x64-msvc": "1.33.0"
+      }
+    },
+    "node_modules/vite/node_modules/lightningcss-android-arm64": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-android-arm64/-/lightningcss-android-arm64-1.33.0.tgz",
+      "integrity": "sha512-gEpRTalKdosp4Bb8qWtc2iOgE5SeIHlpS1up9bFq2wAyYhl1UdTObYiHe98zEM9SQvSoqQZ1IQD0JNpg3Ml5pg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/vite/node_modules/lightningcss-darwin-arm64": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-darwin-arm64/-/lightningcss-darwin-arm64-1.33.0.tgz",
+      "integrity": "sha512-Sciaz8eenNTKn9b3t7+xr0ipTp9YxKQY4npwQ3mrRuL0BAVHBLyZxofhaKBAVtzmtRZ/zTyo0/to4B1uWG/Djg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/vite/node_modules/lightningcss-darwin-x64": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-darwin-x64/-/lightningcss-darwin-x64-1.33.0.tgz",
+      "integrity": "sha512-Z5UPAxzrjlWNNyGy6i65cJzzvgJ5D3T6wMvs+gWpY9d7qRhANrxqAp6LhxIgZhWEw18RfJTGcRxjuLIBr+m8XQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/vite/node_modules/lightningcss-freebsd-x64": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-freebsd-x64/-/lightningcss-freebsd-x64-1.33.0.tgz",
+      "integrity": "sha512-QQM/Ti/hQajJwCY+RiWuCZ9sdtI/XQk7nDK5vC8kkdwixezOlDgvDx7+RT+QjK6FcFT4MpsuoBnHIo/O3StRRg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/vite/node_modules/lightningcss-linux-arm-gnueabihf": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm-gnueabihf/-/lightningcss-linux-arm-gnueabihf-1.33.0.tgz",
+      "integrity": "sha512-N7FVBe6iS24MlM6R/4RBTxGhQheZGs7tiQ9U32UtF75NzP5Q7xWPRqLBCKxlRQRk3rY1jCIPLzx7WzOhuUIRLQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/vite/node_modules/lightningcss-linux-arm64-gnu": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-gnu/-/lightningcss-linux-arm64-gnu-1.33.0.tgz",
+      "integrity": "sha512-j2v/itmy4HlNxlc6voKXYgBqNi0Ng2LShg4z7GufpEgs05P+2suBVyi9I6YHq5uoVFx9ETin3eCEhLVyXGQnKg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/vite/node_modules/lightningcss-linux-arm64-musl": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-musl/-/lightningcss-linux-arm64-musl-1.33.0.tgz",
+      "integrity": "sha512-yiO5ROMuYQgXbC60yjZU5CYSFZGKXL0HFATXt9mHJn1+zW55oCtMI9NfcVhYLMFDL7gV7oBPon/EmMMGg2OvtQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/vite/node_modules/lightningcss-linux-x64-gnu": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-gnu/-/lightningcss-linux-x64-gnu-1.33.0.tgz",
+      "integrity": "sha512-ar+Ju7LmcN0Jo4FpL4hpFybwNG9/3A/Br5KW2n2jyODg3MEZXaDYADdemoNS+BDNfMgKvylJLj4S5tyRActuAg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/vite/node_modules/lightningcss-linux-x64-musl": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-musl/-/lightningcss-linux-x64-musl-1.33.0.tgz",
+      "integrity": "sha512-RYiYbkokw0trfKqqzfF55lginwEPrD3OJDfTuJzFs1MK6iFnDenaz1fqLLtX4ITG3OktJQXOeTaw1awrBAlZPw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/vite/node_modules/lightningcss-win32-arm64-msvc": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-win32-arm64-msvc/-/lightningcss-win32-arm64-msvc-1.33.0.tgz",
+      "integrity": "sha512-1K+MPfLSFVpphzpdbfkhlWk6wBrTObBzS2T6db10PNOZgR9GoVsAWzwNyuhUYYbTp23j+4RrncfujZ4uAzXvwA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/vite/node_modules/lightningcss-win32-x64-msvc": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-win32-x64-msvc/-/lightningcss-win32-x64-msvc-1.33.0.tgz",
+      "integrity": "sha512-OlEICDx/Xl0FqSp4bry8zFnCvGpig3Gl4gCquvYwHuqJKEC1+n9NgDniFvqHGmMv1ZkqDJrDqKKSykTDX+ehuA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/vite/node_modules/picomatch": {
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.5.tgz",
+      "integrity": "sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/vitest": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.10.tgz",
+      "integrity": "sha512-R9jUTe5S4Qb0HCd4TNqpC7oGcrMssMRGXLW80ubjWsW9VH5GF8y1Y0SFLY9AbqSk6nt0PnOx4H4WNJYZ13GUPw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/expect": "4.1.10",
+        "@vitest/mocker": "4.1.10",
+        "@vitest/pretty-format": "4.1.10",
+        "@vitest/runner": "4.1.10",
+        "@vitest/snapshot": "4.1.10",
+        "@vitest/spy": "4.1.10",
+        "@vitest/utils": "4.1.10",
+        "es-module-lexer": "^2.0.0",
+        "expect-type": "^1.3.0",
+        "magic-string": "^0.30.21",
+        "obug": "^2.1.1",
+        "pathe": "^2.0.3",
+        "picomatch": "^4.0.3",
+        "std-env": "^4.0.0-rc.1",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^1.0.2",
+        "tinyglobby": "^0.2.15",
+        "tinyrainbow": "^3.1.0",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^20.0.0 || ^22.0.0 || >=24.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@opentelemetry/api": "^1.9.0",
+        "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0",
+        "@vitest/browser-playwright": "4.1.10",
+        "@vitest/browser-preview": "4.1.10",
+        "@vitest/browser-webdriverio": "4.1.10",
+        "@vitest/coverage-istanbul": "4.1.10",
+        "@vitest/coverage-v8": "4.1.10",
+        "@vitest/ui": "4.1.10",
+        "happy-dom": "*",
+        "jsdom": "*",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@opentelemetry/api": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser-playwright": {
+          "optional": true
+        },
+        "@vitest/browser-preview": {
+          "optional": true
+        },
+        "@vitest/browser-webdriverio": {
+          "optional": true
+        },
+        "@vitest/coverage-istanbul": {
+          "optional": true
+        },
+        "@vitest/coverage-v8": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        },
+        "vite": {
+          "optional": false
+        }
+      }
+    },
+    "node_modules/vitest/node_modules/picomatch": {
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.5.tgz",
+      "integrity": "sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
     "node_modules/which": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
@@ -7979,6 +8992,23 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/word-wrap": {

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "start": "next start",
     "lint": "eslint . --ext .ts,.tsx,.js,.jsx,.mjs",
     "lint:fix": "eslint . --ext .ts,.tsx,.js,.jsx,.mjs --fix",
+    "test": "vitest run",
     "format": "prettier --write .",
     "format:check": "prettier --check ."
   },
@@ -43,6 +44,7 @@
     "prettier": "^3.7.4",
     "tailwindcss": "^4",
     "tw-animate-css": "^1.4.0",
-    "typescript": "^5"
+    "typescript": "^5",
+    "vitest": "^4.1.10"
   }
 }

--- a/src/app/cursors/page.tsx
+++ b/src/app/cursors/page.tsx
@@ -1,11 +1,14 @@
 import { Header } from "@/components/layout/header";
 import { CursorGrid } from "@/components/gallery/cursor-grid";
 import { Footer } from "@/components/layout/footer";
+import { CURSORS } from "@/registry/cursors";
 
 export const metadata = {
-  title: "All Cursors | Custom Animated Cursors",
-  description:
-    "Browse our full collection of custom animated cursors for your web projects.",
+  title: "All Cursors",
+  description: `Browse the full collection of ${CURSORS.length}+ custom animated cursors for React, Next.js, and Vanilla JS. Optimized for performance, installable via the Shadcn CLI.`,
+  alternates: {
+    canonical: "/cursors",
+  },
 };
 
 export default function CursorsPage() {
@@ -19,8 +22,8 @@ export default function CursorsPage() {
             All Cursors
           </h1>
           <p className="text-muted-foreground max-w-2xl mx-auto">
-            Explore our growing library of 70+ high-quality animated cursors.
-            Optimized for performance and easy to integrate.
+            Explore our growing library of {CURSORS.length}+ high-quality
+            animated cursors. Optimized for performance and easy to integrate.
           </p>
         </div>
         <CursorGrid />

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -6,6 +6,7 @@ import "./globals.css";
 import { ThemeProvider } from "@/components/theme-provider";
 import { CursorProvider } from "@/components/cursor/cursor-context";
 import { CursorEngine } from "@/components/cursor/cursor-engine";
+import { CURSORS } from "@/registry/cursors";
 
 const geistSans = Geist({
   variable: "--font-geist-sans",
@@ -19,33 +20,63 @@ const geistMono = Geist_Mono({
 
 export const metadata: Metadata = {
   metadataBase: new URL("https://cursor-gallery.vercel.app"),
-  title: "Cursor Gallery -Premium Animated Cursors for React",
-  description:
-    "A curated collection of high-end animated cursors. Engineered for performance, designed for impact. Copy-paste ready for React, Next.js, and Vanilla JS.",
+  title: {
+    default: "Cursor Gallery — Premium Animated Cursors for React & Next.js",
+    template: "%s | Cursor Gallery",
+  },
+  description: `A curated collection of ${CURSORS.length}+ high-end animated cursors. Engineered for performance, designed for impact. Copy-paste ready for React, Next.js, and Vanilla JS — install in seconds with the Shadcn CLI.`,
   keywords: [
+    "animated cursors",
+    "custom cursor",
+    "custom cursor react",
+    "react cursor component",
+    "nextjs custom cursor",
+    "shadcn cursor",
+    "shadcn registry",
+    "framer motion cursor",
+    "animated mouse pointer",
+    "cursor effects",
+    "cursor animation library",
+    "custom pointer css",
+    "mouse trail effect",
     "react",
-    "cursor",
-    "animation",
+    "next.js",
     "framer motion",
     "ui design",
-    "frontend",
-    "animated cursors",
-    "custom pointer",
+    "micro-interactions",
     "web design",
+    "frontend",
   ],
-  authors: [{ name: "Aadi Chowdhury" }],
+  authors: [{ name: "Aadi Chowdhury", url: "https://heyaadi.com" }],
+  creator: "Aadi Chowdhury",
+  publisher: "Cursor Gallery",
+  category: "technology",
+  alternates: {
+    canonical: "/",
+  },
+  robots: {
+    index: true,
+    follow: true,
+    googleBot: {
+      index: true,
+      follow: true,
+      "max-video-preview": -1,
+      "max-image-preview": "large",
+      "max-snippet": -1,
+    },
+  },
   openGraph: {
     type: "website",
     locale: "en_US",
     url: "https://cursor-gallery.vercel.app",
-    title: "Cursor Gallery - Premium Animated Cursors",
+    title: "Cursor Gallery — Premium Animated Cursors for React & Next.js",
     description:
       "Elevate your web UX with beautiful animated cursors, copy-paste ready for your next project.",
     siteName: "Cursor Gallery",
   },
   twitter: {
     card: "summary_large_image",
-    title: "Cursor Gallery - Premium Animated Cursors",
+    title: "Cursor Gallery — Premium Animated Cursors",
     description:
       "Elevate your web UX with beautiful animated cursors, copy-paste ready for your next project.",
     creator: "@AadiChowdhury7",

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -7,10 +7,46 @@ import { Button } from "@/components/ui/button";
 import { CLISection } from "@/components/layout/cli-section";
 import Link from "next/link";
 import { ArrowRight } from "lucide-react";
+import { CURSORS } from "@/registry/cursors";
+
+const JSON_LD = {
+  "@context": "https://schema.org",
+  "@graph": [
+    {
+      "@type": "WebSite",
+      name: "Cursor Gallery",
+      url: "https://cursor-gallery.vercel.app",
+      description:
+        "A curated collection of high-end animated cursors for React, Next.js, and Vanilla JS.",
+    },
+    {
+      "@type": "SoftwareApplication",
+      name: "Cursor Gallery",
+      applicationCategory: "DeveloperApplication",
+      operatingSystem: "Web",
+      url: "https://cursor-gallery.vercel.app",
+      description: `A curated collection of ${CURSORS.length}+ premium animated cursors. Copy-paste ready for React, Next.js, and Vanilla JS via the Shadcn CLI.`,
+      offers: {
+        "@type": "Offer",
+        price: "0",
+        priceCurrency: "USD",
+      },
+      author: {
+        "@type": "Person",
+        name: "Aadi Chowdhury",
+        url: "https://heyaadi.com",
+      },
+    },
+  ],
+};
 
 export default function Home() {
   return (
     <div className="min-h-screen flex flex-col">
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{ __html: JSON.stringify(JSON_LD) }}
+      />
       <Header />
 
       <main className="flex-1">

--- a/src/app/robots.ts
+++ b/src/app/robots.ts
@@ -1,0 +1,14 @@
+import type { MetadataRoute } from "next";
+
+const BASE_URL = "https://cursor-gallery.vercel.app";
+
+export default function robots(): MetadataRoute.Robots {
+  return {
+    rules: {
+      userAgent: "*",
+      allow: "/",
+      disallow: ["/api/"],
+    },
+    sitemap: `${BASE_URL}/sitemap.xml`,
+  };
+}

--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -1,0 +1,26 @@
+import type { MetadataRoute } from "next";
+
+const BASE_URL = "https://cursor-gallery.vercel.app";
+
+export default function sitemap(): MetadataRoute.Sitemap {
+  return [
+    {
+      url: BASE_URL,
+      lastModified: new Date(),
+      changeFrequency: "weekly",
+      priority: 1,
+    },
+    {
+      url: `${BASE_URL}/cursors`,
+      lastModified: new Date(),
+      changeFrequency: "weekly",
+      priority: 0.9,
+    },
+    {
+      url: `${BASE_URL}/sponsor`,
+      lastModified: new Date(),
+      changeFrequency: "monthly",
+      priority: 0.5,
+    },
+  ];
+}

--- a/src/app/sponsor/page.tsx
+++ b/src/app/sponsor/page.tsx
@@ -3,7 +3,15 @@
 import { Header } from "@/components/layout/header";
 import { Footer } from "@/components/layout/footer";
 import { Button } from "@/components/ui/button";
-import { Heart, Github, Twitter, Coffee, Star } from "lucide-react";
+import {
+  Heart,
+  Github,
+  Twitter,
+  Coffee,
+  Star,
+  Sparkles,
+  ArrowUpRight,
+} from "lucide-react";
 import Link from "next/link";
 import { motion } from "framer-motion";
 
@@ -109,6 +117,55 @@ export default function SponsorPage() {
                 </Button>
               </motion.div>
             </div>
+
+            {/* About the Maker */}
+            <motion.div
+              initial={{ opacity: 0, y: 20 }}
+              animate={{ opacity: 1, y: 0 }}
+              transition={{ duration: 0.6, delay: 0.35 }}
+              className="mb-16 p-8 md:p-10 rounded-[2rem] border bg-card/50 backdrop-blur-sm relative overflow-hidden"
+            >
+              <div className="absolute top-0 left-0 w-full h-1 bg-gradient-to-r from-transparent via-primary/60 to-transparent" />
+              <div className="flex flex-col md:flex-row items-start md:items-center gap-8">
+                <div className="w-16 h-16 rounded-2xl bg-primary/10 border border-primary/20 flex items-center justify-center shrink-0">
+                  <Sparkles className="w-7 h-7 text-primary" />
+                </div>
+                <div className="flex-1">
+                  <p className="text-[10px] font-black uppercase tracking-[0.2em] text-primary mb-3">
+                    Meet the Maker
+                  </p>
+                  <h2 className="text-2xl md:text-3xl font-bold tracking-tight mb-3">
+                    Hi, I&apos;m Aadi — a design engineer.
+                  </h2>
+                  <p className="text-muted-foreground leading-relaxed mb-2">
+                    I&apos;ve designed and engineered products for brands like{" "}
+                    <span className="text-foreground font-semibold">
+                      Philips
+                    </span>{" "}
+                    and{" "}
+                    <span className="text-foreground font-semibold">
+                      Hero MotoCorp
+                    </span>
+                    , and helped early-stage startups ship interfaces that feel
+                    as good as they look.
+                  </p>
+                  <p className="text-muted-foreground leading-relaxed">
+                    Cursor Gallery is my love letter to the tiny details — the
+                    micro-interactions most people feel but never notice.
+                  </p>
+                  <Button
+                    asChild
+                    variant="link"
+                    className="px-0 mt-4 h-auto font-bold text-primary hover:text-primary/80"
+                  >
+                    <Link href="https://heyaadi.com" target="_blank">
+                      More about me
+                      <ArrowUpRight className="w-4 h-4 ml-1" />
+                    </Link>
+                  </Button>
+                </div>
+              </div>
+            </motion.div>
 
             <motion.div
               initial={{ opacity: 0, y: 20 }}

--- a/src/components/cursor/cursor-context.tsx
+++ b/src/components/cursor/cursor-context.tsx
@@ -7,47 +7,56 @@ import React, {
   useEffect,
   useCallback,
   useMemo,
+  useRef,
 } from "react";
 
 type CursorStyle = string;
 
-interface CursorContextType {
+interface CursorStateContextType {
   cursorStyle: CursorStyle;
+  isCursorVisible: boolean;
+}
+
+interface CursorActionsContextType {
   setCursor: (style: CursorStyle) => void;
   resetCursor: () => void;
   lockCursor: (style: CursorStyle) => void;
   unlockCursor: () => void;
-  isCursorVisible: boolean;
 }
 
-const CursorContext = createContext<CursorContextType | undefined>(undefined);
+// Split into two contexts so components that only *dispatch* cursor changes
+// (e.g. every gallery card) never re-render when the active cursor changes.
+const CursorStateContext = createContext<CursorStateContextType | undefined>(
+  undefined
+);
+const CursorActionsContext = createContext<
+  CursorActionsContextType | undefined
+>(undefined);
 
 export function CursorProvider({ children }: { children: React.ReactNode }) {
   const [cursorStyle, setCursorStyle] = useState<CursorStyle>("default");
-  const [isLocked, setIsLocked] = useState(false);
   const [isCursorVisible] = useState(true);
+  // Ref-based lock keeps all action callbacks referentially stable forever,
+  // so the actions context value never changes identity.
+  const isLockedRef = useRef(false);
 
-  // Memoize callbacks to prevent re-renders in children
-  const setCursor = useCallback(
-    (style: CursorStyle) => {
-      if (isLocked) return;
-      setCursorStyle(style);
-    },
-    [isLocked]
-  );
+  const setCursor = useCallback((style: CursorStyle) => {
+    if (isLockedRef.current) return;
+    setCursorStyle(style);
+  }, []);
 
   const resetCursor = useCallback(() => {
-    if (isLocked) return;
+    if (isLockedRef.current) return;
     setCursorStyle("default");
-  }, [isLocked]);
+  }, []);
 
   const lockCursor = useCallback((style: CursorStyle) => {
+    isLockedRef.current = true;
     setCursorStyle(style);
-    setIsLocked(true);
   }, []);
 
   const unlockCursor = useCallback(() => {
-    setIsLocked(false);
+    isLockedRef.current = false;
     setCursorStyle("default");
   }, []);
 
@@ -83,62 +92,41 @@ export function CursorProvider({ children }: { children: React.ReactNode }) {
     };
   }, []);
 
-  // Memoize context value to prevent re-renders when cursorStyle changes
-  // Only CursorEngine needs to react to cursorStyle changes
-  const contextValue = useMemo(
-    () => ({
-      cursorStyle,
-      setCursor,
-      resetCursor,
-      lockCursor,
-      unlockCursor,
-      isCursorVisible,
-    }),
-    [
-      cursorStyle,
-      setCursor,
-      resetCursor,
-      lockCursor,
-      unlockCursor,
-      isCursorVisible,
-    ]
+  const stateValue = useMemo(
+    () => ({ cursorStyle, isCursorVisible }),
+    [cursorStyle, isCursorVisible]
+  );
+
+  const actionsValue = useMemo(
+    () => ({ setCursor, resetCursor, lockCursor, unlockCursor }),
+    [setCursor, resetCursor, lockCursor, unlockCursor]
   );
 
   return (
-    <CursorContext.Provider value={contextValue}>
-      {children}
-    </CursorContext.Provider>
+    <CursorActionsContext.Provider value={actionsValue}>
+      <CursorStateContext.Provider value={stateValue}>
+        {children}
+      </CursorStateContext.Provider>
+    </CursorActionsContext.Provider>
   );
 }
 
+// For components that need to READ the active cursor (e.g. CursorEngine)
 export function useCursor() {
-  const context = useContext(CursorContext);
-  if (context === undefined) {
+  const state = useContext(CursorStateContext);
+  const actions = useContext(CursorActionsContext);
+  if (state === undefined || actions === undefined) {
     throw new Error("useCursor must be used within a CursorProvider");
   }
-  return context;
+  return { ...state, ...actions };
 }
 
-// Separate hook for components that only need to SET cursor (not read cursorStyle)
-// This prevents re-renders when cursorStyle changes
+// For components that only SET the cursor. Subscribing to the actions
+// context alone means zero re-renders when the active cursor style changes.
 export function useCursorActions() {
-  const context = useContext(CursorContext);
+  const context = useContext(CursorActionsContext);
   if (context === undefined) {
     throw new Error("useCursorActions must be used within a CursorProvider");
   }
-  // Return only the stable, memoized functions
-  return useMemo(
-    () => ({
-      setCursor: context.setCursor,
-      resetCursor: context.resetCursor,
-      lockCursor: context.lockCursor,
-      unlockCursor: context.unlockCursor,
-    }),
-    [
-      context.setCursor,
-      context.resetCursor,
-      context.lockCursor,
-      context.unlockCursor,
-    ]
-  );
+  return context;
 }

--- a/src/components/cursor/cursor-engine.tsx
+++ b/src/components/cursor/cursor-engine.tsx
@@ -11,7 +11,9 @@ import React, {
 import { useCursor } from "@/components/cursor/cursor-context";
 import { CURSORS } from "@/registry/cursors";
 
-// Memoized cursor renderer to prevent unnecessary re-renders
+// Memoized cursor renderer. Re-renders only when the component, hover state,
+// or actual position changes — no dead-zone, so precise slow movements stay
+// pixel-perfect and never feel "stuck".
 const CursorRenderer = memo(
   ({
     Component,
@@ -31,12 +33,11 @@ const CursorRenderer = memo(
     return <Component x={x} y={y} isHovering={isHovering} />;
   },
   (prev, next) => {
-    // Only re-render if position changed significantly (> 2px) or component/hover changed
     return (
       prev.Component === next.Component &&
       prev.isHovering === next.isHovering &&
-      Math.abs(prev.x - next.x) < 2 &&
-      Math.abs(prev.y - next.y) < 2
+      prev.x === next.x &&
+      prev.y === next.y
     );
   }
 );
@@ -49,11 +50,11 @@ export function CursorEngine() {
   const [hasMoved, setHasMoved] = useState(false);
   const [isHovering, setIsHovering] = useState(false);
 
-  // Use refs to track position without triggering re-renders
+  // Refs keep the mousemove handler free of re-renders
   const positionRef = useRef({ x: 0, y: 0 });
-  const rafIdRef = useRef<number | null>(null);
-  const lastUpdateRef = useRef(0);
+  const frameRef = useRef<number | null>(null);
   const hasMovedRef = useRef(false);
+  const isHoveringRef = useRef(false);
 
   // Build cursor map from registry - memoized
   const CURSOR_MAP = useMemo(() => {
@@ -67,42 +68,44 @@ export function CursorEngine() {
     );
   }, [cursorStyle, CURSOR_MAP]);
 
-  // Stable mouse move handler using refs
+  // Stable mouse move handler. Schedules at most ONE state update per frame —
+  // never cancels/reschedules, so high-polling-rate mice (120Hz+) can't starve
+  // the animation frame and freeze the cursor mid-movement.
   const handleMouseMove = useCallback((e: MouseEvent) => {
-    // Update ref immediately (no re-render)
-    positionRef.current = { x: e.clientX, y: e.clientY };
+    positionRef.current.x = e.clientX;
+    positionRef.current.y = e.clientY;
 
     if (!hasMovedRef.current) {
       hasMovedRef.current = true;
       setHasMoved(true);
     }
 
-    // Check for interactive elements
+    // Interactive-element detection (only set state on actual change)
     const target = e.target as HTMLElement;
-    // Expand detection to include common interactive elements
     const interactive = !!target.closest(
       'button, a, input, [role="button"], label, select, textarea, .cursor-pointer'
     );
-    setIsHovering(interactive);
+    if (isHoveringRef.current !== interactive) {
+      isHoveringRef.current = interactive;
+      setIsHovering(interactive);
+    }
 
-    // Throttle React state updates to ~60fps
-    const now = performance.now();
-    if (now - lastUpdateRef.current < 16) return;
-
-    if (rafIdRef.current) cancelAnimationFrame(rafIdRef.current);
-
-    rafIdRef.current = requestAnimationFrame(() => {
-      setMousePosition({ x: positionRef.current.x, y: positionRef.current.y });
-      lastUpdateRef.current = now;
-      rafIdRef.current = null;
-    });
+    if (frameRef.current === null) {
+      frameRef.current = requestAnimationFrame(() => {
+        frameRef.current = null;
+        setMousePosition({
+          x: positionRef.current.x,
+          y: positionRef.current.y,
+        });
+      });
+    }
   }, []);
 
   useEffect(() => {
     window.addEventListener("mousemove", handleMouseMove, { passive: true });
     return () => {
       window.removeEventListener("mousemove", handleMouseMove);
-      if (rafIdRef.current) cancelAnimationFrame(rafIdRef.current);
+      if (frameRef.current !== null) cancelAnimationFrame(frameRef.current);
     };
   }, [handleMouseMove]);
 

--- a/src/components/gallery/cursor-card.tsx
+++ b/src/components/gallery/cursor-card.tsx
@@ -89,11 +89,14 @@ export const CursorCard = memo(function CursorCard({
               )}
             >
               <div className="flex items-center justify-center w-0 h-0 text-foreground">
-                {/* 
-                          We pass isStatic={true} to the component. 
-                          The component will render its core shape but skip the heavy animations/intervals.
+                {/*
+                          Always rendered in static mode: the live, fully animated
+                          instance already follows the real mouse via CursorEngine,
+                          so mounting a second animated instance here on hover would
+                          double the work (intervals, springs) for a backdrop that is
+                          blurred down to 20% opacity anyway.
                         */}
-                <CursorComponent x={0} y={0} isStatic={!isHovered} />
+                <CursorComponent x={0} y={0} isStatic={true} />
               </div>
             </div>
           )}

--- a/src/components/gallery/cursor-grid.tsx
+++ b/src/components/gallery/cursor-grid.tsx
@@ -9,7 +9,15 @@ import { motion } from "framer-motion";
 import { Search } from "lucide-react";
 import { cn } from "@/lib/utils";
 
-const CATEGORIES = ["All", "Minimal", "Effect", "Shape", "Dark Mode"];
+const CATEGORIES = [
+  "All",
+  "Minimal",
+  "Effect",
+  "Shape",
+  "Animated",
+  "Creative",
+  "Dark Mode",
+];
 
 export function CursorGrid({
   onlyFeatured = false,

--- a/src/components/layout/footer.tsx
+++ b/src/components/layout/footer.tsx
@@ -1,5 +1,6 @@
 import Link from "next/link";
 import { Github, Twitter, Coffee, PlusCircle } from "lucide-react";
+import { CURSORS } from "@/registry/cursors";
 
 export function Footer() {
   return (
@@ -11,9 +12,9 @@ export function Footer() {
             Cursor Gallery
           </span>
           <p className="text-sm text-muted-foreground leading-relaxed">
-            A curated collection of 70+ high-end animated cursors. Engineered
-            for performance, designed for impact. Free and open-source for the
-            modern web.
+            A curated collection of {CURSORS.length}+ high-end animated cursors.
+            Engineered for performance, designed for impact. Free and
+            open-source for the modern web.
           </p>
         </div>
 

--- a/src/registry/cursors/aperture.tsx
+++ b/src/registry/cursors/aperture.tsx
@@ -1,0 +1,90 @@
+"use client";
+
+import { motion } from "framer-motion";
+
+const CENTER = 17;
+const BLADE_COUNT = 6;
+
+export default function ApertureCursor({
+  x,
+  y,
+  isHovering,
+  isStatic,
+}: {
+  x: number;
+  y: number;
+  isHovering?: boolean;
+  isStatic?: boolean;
+}) {
+  const blades = Array.from({ length: BLADE_COUNT }, (_, i) => {
+    const a = (i * 360) / BLADE_COUNT;
+    const rad = (a * Math.PI) / 180;
+    const rad2 = ((a + 44) * Math.PI) / 180;
+    return {
+      x1: CENTER + 13 * Math.cos(rad),
+      y1: CENTER + 13 * Math.sin(rad),
+      x2: CENTER + 5.5 * Math.cos(rad2),
+      y2: CENTER + 5.5 * Math.sin(rad2),
+    };
+  });
+
+  return (
+    <motion.div
+      className="fixed top-0 left-0 pointer-events-none z-50"
+      style={{ x, y, translateX: "-50%", translateY: "-50%" }}
+    >
+      <motion.div
+        animate={{
+          rotate: isStatic ? 0 : 360,
+          scale: isHovering ? 1.25 : 1,
+        }}
+        transition={{
+          rotate: { duration: 9, repeat: Infinity, ease: "linear" },
+          scale: { type: "spring", stiffness: 320, damping: 20 },
+        }}
+      >
+        <svg
+          width="34"
+          height="34"
+          viewBox="0 0 34 34"
+          style={{
+            filter: "drop-shadow(0 0 6px rgba(45,212,191,0.45))",
+          }}
+        >
+          <circle
+            cx={CENTER}
+            cy={CENTER}
+            r="15.5"
+            fill="none"
+            stroke="#2dd4bf"
+            strokeWidth="1.5"
+            opacity="0.9"
+          />
+          <circle
+            cx={CENTER}
+            cy={CENTER}
+            r="4"
+            fill="none"
+            stroke="#2dd4bf"
+            strokeWidth="1.2"
+            opacity="0.8"
+          />
+          {blades.map((b, i) => (
+            <line
+              key={i}
+              x1={b.x1}
+              y1={b.y1}
+              x2={b.x2}
+              y2={b.y2}
+              stroke="#5eead4"
+              strokeWidth="1.4"
+              strokeLinecap="round"
+            />
+          ))}
+        </svg>
+      </motion.div>
+      {/* Center pip */}
+      <div className="absolute left-1/2 top-1/2 w-1 h-1 -translate-x-1/2 -translate-y-1/2 rounded-full bg-teal-300" />
+    </motion.div>
+  );
+}

--- a/src/registry/cursors/aurora.tsx
+++ b/src/registry/cursors/aurora.tsx
@@ -1,0 +1,49 @@
+"use client";
+
+import { motion } from "framer-motion";
+
+export default function AuroraCursor({
+  x,
+  y,
+  isStatic,
+}: {
+  x: number;
+  y: number;
+  isStatic?: boolean;
+}) {
+  return (
+    <>
+      {/* Flowing aurora wash */}
+      <motion.div
+        className="fixed top-0 left-0 w-[160px] h-[160px] rounded-full pointer-events-none z-40"
+        style={{
+          x,
+          y,
+          translateX: "-50%",
+          translateY: "-50%",
+          background:
+            "conic-gradient(from 0deg, rgba(52,211,153,0.35), rgba(34,211,238,0.35), rgba(167,139,250,0.4), rgba(52,211,153,0.35))",
+          filter: "blur(30px)",
+        }}
+        animate={isStatic ? {} : { rotate: 360, scale: [1, 1.15, 1] }}
+        transition={{
+          rotate: { duration: 7, repeat: Infinity, ease: "linear" },
+          scale: { duration: 3.5, repeat: Infinity, ease: "easeInOut" },
+        }}
+      />
+      {/* Core dot */}
+      <motion.div
+        className="fixed top-0 left-0 w-4 h-4 rounded-full pointer-events-none z-50"
+        style={{
+          x,
+          y,
+          translateX: "-50%",
+          translateY: "-50%",
+          background: "linear-gradient(135deg, #34d399 0%, #22d3ee 100%)",
+          boxShadow:
+            "0 0 20px rgba(52,211,153,0.7), 0 0 44px rgba(34,211,238,0.4)",
+        }}
+      />
+    </>
+  );
+}

--- a/src/registry/cursors/butterfly.tsx
+++ b/src/registry/cursors/butterfly.tsx
@@ -1,0 +1,102 @@
+"use client";
+
+import { motion } from "framer-motion";
+
+export default function ButterflyCursor({
+  x,
+  y,
+  isStatic,
+}: {
+  x: number;
+  y: number;
+  isStatic?: boolean;
+}) {
+  const flap = isStatic ? {} : { scaleX: [1, 0.35, 1] };
+
+  return (
+    <motion.div
+      className="fixed top-0 left-0 pointer-events-none z-50"
+      style={{ x, y, translateX: "-50%", translateY: "-50%" }}
+    >
+      <motion.div
+        animate={isStatic ? {} : { rotate: [0, -6, 6, 0] }}
+        transition={{ duration: 3, repeat: Infinity, ease: "easeInOut" }}
+        style={{ filter: "drop-shadow(0 0 8px rgba(129,140,248,0.5))" }}
+      >
+        <svg width="30" height="26" viewBox="0 0 30 26">
+          {/* Left wing */}
+          <motion.g
+            style={{ transformOrigin: "15px 13px" }}
+            animate={flap}
+            transition={{ duration: 0.85, repeat: Infinity, ease: "easeInOut" }}
+          >
+            <path
+              d="M15 11 C9 2 2 1 3 7 C3.6 11.5 9 13 15 12.4 Z"
+              fill="url(#butterflyGradL)"
+            />
+            <path
+              d="M15 13.6 C9 14 4 16.5 6 20.5 C8 24 13 19.5 15 15 Z"
+              fill="url(#butterflyGradL)"
+              opacity="0.85"
+            />
+          </motion.g>
+          {/* Right wing */}
+          <motion.g
+            style={{ transformOrigin: "15px 13px" }}
+            animate={flap}
+            transition={{ duration: 0.85, repeat: Infinity, ease: "easeInOut" }}
+          >
+            <path
+              d="M15 11 C21 2 28 1 27 7 C26.4 11.5 21 13 15 12.4 Z"
+              fill="url(#butterflyGradR)"
+            />
+            <path
+              d="M15 13.6 C21 14 26 16.5 24 20.5 C22 24 17 19.5 15 15 Z"
+              fill="url(#butterflyGradR)"
+              opacity="0.85"
+            />
+          </motion.g>
+          {/* Body */}
+          <rect
+            x="14.2"
+            y="7"
+            width="1.6"
+            height="11"
+            rx="0.8"
+            fill="#312e81"
+          />
+          {/* Antennae */}
+          <path
+            d="M14.6 7.5 C13 5 11.5 4.5 10.5 3.5 M15.4 7.5 C17 5 18.5 4.5 19.5 3.5"
+            stroke="#312e81"
+            strokeWidth="0.8"
+            strokeLinecap="round"
+            fill="none"
+          />
+          <defs>
+            <linearGradient
+              id="butterflyGradL"
+              x1="0%"
+              y1="0%"
+              x2="100%"
+              y2="100%"
+            >
+              <stop offset="0%" stopColor="#818cf8" />
+              <stop offset="100%" stopColor="#c084fc" />
+            </linearGradient>
+            <linearGradient
+              id="butterflyGradR"
+              x1="100%"
+              y1="0%"
+              x2="0%"
+              y2="100%"
+            >
+              <stop offset="0%" stopColor="#818cf8" />
+              <stop offset="100%" stopColor="#c084fc" />
+            </linearGradient>
+          </defs>
+        </svg>
+      </motion.div>
+    </motion.div>
+  );
+}

--- a/src/registry/cursors/chromatic.tsx
+++ b/src/registry/cursors/chromatic.tsx
@@ -1,0 +1,40 @@
+"use client";
+
+import { motion, useMotionValue, useSpring } from "framer-motion";
+import { useEffect } from "react";
+
+export default function ChromaticCursor({ x, y }: { x: number; y: number }) {
+  const mx = useMotionValue(x);
+  const my = useMotionValue(y);
+
+  useEffect(() => {
+    mx.set(x);
+    my.set(y);
+  }, [x, y, mx, my]);
+
+  // Two color ghosts trail at different speeds — chromatic aberration
+  const cyanX = useSpring(mx, { stiffness: 320, damping: 24, mass: 0.5 });
+  const cyanY = useSpring(my, { stiffness: 320, damping: 24, mass: 0.5 });
+  const pinkX = useSpring(mx, { stiffness: 130, damping: 16, mass: 0.8 });
+  const pinkY = useSpring(my, { stiffness: 130, damping: 16, mass: 0.8 });
+
+  return (
+    <>
+      {/* Pink ghost (slowest) */}
+      <motion.div
+        className="fixed top-0 left-0 w-4 h-4 rounded-full pointer-events-none z-40 bg-pink-400/70 blur-[1px]"
+        style={{ x: pinkX, y: pinkY, translateX: "-50%", translateY: "-50%" }}
+      />
+      {/* Cyan ghost */}
+      <motion.div
+        className="fixed top-0 left-0 w-4 h-4 rounded-full pointer-events-none z-40 bg-cyan-400/70 blur-[1px]"
+        style={{ x: cyanX, y: cyanY, translateX: "-50%", translateY: "-50%" }}
+      />
+      {/* Primary dot */}
+      <motion.div
+        className="fixed top-0 left-0 w-3.5 h-3.5 rounded-full pointer-events-none z-50 bg-foreground"
+        style={{ x, y, translateX: "-50%", translateY: "-50%" }}
+      />
+    </>
+  );
+}

--- a/src/registry/cursors/coffee.tsx
+++ b/src/registry/cursors/coffee.tsx
@@ -1,55 +1,110 @@
 "use client";
+
 import { motion } from "framer-motion";
 
-export default function CoffeeCursor({ x, y }: { x: number; y: number }) {
+export default function CoffeeCursor({
+  x,
+  y,
+  isHovering,
+  isStatic,
+}: {
+  x: number;
+  y: number;
+  isHovering?: boolean;
+  isStatic?: boolean;
+}) {
   return (
     <motion.div
-      className="fixed top-0 left-0 pointer-events-none z-50 flex items-center justify-center"
+      className="fixed top-0 left-0 pointer-events-none z-50"
       style={{ x, y, translateX: "-50%", translateY: "-50%" }}
     >
-      <div className="relative">
-        <div className="absolute -top-4 w-full flex justify-center space-x-1">
-          {[0, 1, 2].map((i) => (
-            <motion.div
-              key={i}
-              className="w-1 h-3 bg-white/30 rounded-full blur-[1px]"
-              animate={{ y: [-2, -10], opacity: [0, 0.6, 0] }}
-              transition={{
-                duration: 1.5,
-                repeat: Infinity,
-                delay: i * 0.4,
-                ease: "easeOut",
-              }}
-            />
-          ))}
-        </div>
-        <svg
-          width="28"
-          height="28"
-          viewBox="0 0 24 24"
-          fill="none"
-          xmlns="http://www.w3.org/2000/svg"
-        >
-          <path
-            d="M5 8H19V11C19 15.4183 15.4183 19 11 19V19C6.58172 19 3 15.4183 3 11V10H5V8Z"
-            fill="#78350f"
-            stroke="#92400e"
-            strokeWidth="2"
+      {/* Steam wisps */}
+      {!isStatic &&
+        [0, 1, 2].map((i) => (
+          <motion.div
+            key={i}
+            className="absolute w-[3px] h-[10px] bg-white/40 rounded-full blur-[1.5px]"
+            style={{ left: 11 + i * 5, top: -12 }}
+            animate={{
+              y: [-2, -12],
+              x: [0, (i - 1) * 3],
+              opacity: [0, 0.7, 0],
+              scaleY: [0.6, 1.3],
+            }}
+            transition={{
+              duration: 1.6,
+              repeat: Infinity,
+              delay: i * 0.45,
+              ease: "easeOut",
+            }}
           />
+        ))}
+
+      <motion.div
+        animate={{
+          rotate: isHovering ? -6 : 0,
+          scale: isHovering ? 1.08 : 1,
+        }}
+        transition={{ type: "spring", stiffness: 300, damping: 18 }}
+        style={{ filter: "drop-shadow(0 0 8px rgba(120,53,15,0.4))" }}
+      >
+        <svg width="30" height="34" viewBox="0 0 30 34">
+          <defs>
+            <linearGradient id="coffeeCup" x1="0%" y1="0%" x2="0%" y2="100%">
+              <stop offset="0%" stopColor="#f5f0e8" />
+              <stop offset="100%" stopColor="#d6c9b4" />
+            </linearGradient>
+            <linearGradient
+              id="coffeeSleeve"
+              x1="0%"
+              y1="0%"
+              x2="100%"
+              y2="100%"
+            >
+              <stop offset="0%" stopColor="#a16207" />
+              <stop offset="100%" stopColor="#78350f" />
+            </linearGradient>
+          </defs>
+
+          {/* Lid */}
           <path
-            d="M19 8H20C21.1046 8 22 8.89543 22 10V11C22 12.1046 21.1046 13 20 13H19"
-            stroke="#92400e"
-            strokeWidth="2"
-            strokeLinecap="round"
+            d="M6 8 L7.4 4.5 C7.6 4 8.1 3.5 8.7 3.5 L21.3 3.5 C21.9 3.5 22.4 4 22.6 4.5 L24 8 Z"
+            fill="#e7e0d2"
+            stroke="#b8ab91"
+            strokeWidth="0.6"
           />
+          <rect
+            x="12"
+            y="1.8"
+            width="6"
+            height="2.2"
+            rx="1.1"
+            fill="#e7e0d2"
+            stroke="#b8ab91"
+            strokeWidth="0.5"
+          />
+
+          {/* Cup body (tapered) */}
           <path
-            d="M7 19H17"
-            stroke="#92400e"
-            strokeWidth="2"
+            d="M6 8 L24 8 L22.2 30 C22.1 31.1 21.2 32 20.1 32 L9.9 32 C8.8 32 7.9 31.1 7.8 30 Z"
+            fill="url(#coffeeCup)"
+            stroke="#b8ab91"
+            strokeWidth="0.7"
+          />
+
+          {/* Sleeve */}
+          <path d="M7.2 14 L22.8 14 L22 23 L8 23 Z" fill="url(#coffeeSleeve)" />
+          {/* Coffee bean emblem */}
+          <ellipse cx="15" cy="18.5" rx="2.6" ry="3.4" fill="#451a03" />
+          <path
+            d="M15 15.4 C13.8 17 13.8 20 15 21.6 C16.2 20 16.2 17 15 15.4"
+            stroke="#d6a565"
+            strokeWidth="0.9"
+            fill="none"
             strokeLinecap="round"
           />
         </svg>
-      </div>
+      </motion.div>
     </motion.div>
   );
 }

--- a/src/registry/cursors/comet.tsx
+++ b/src/registry/cursors/comet.tsx
@@ -1,0 +1,71 @@
+"use client";
+
+import { motion } from "framer-motion";
+import { useEffect, useRef, useState } from "react";
+
+export default function CometCursor({
+  x,
+  y,
+  isStatic,
+}: {
+  x: number;
+  y: number;
+  isStatic?: boolean;
+}) {
+  const [angle, setAngle] = useState(-135);
+  const [speed, setSpeed] = useState(0);
+  const prevRef = useRef({ x, y });
+
+  useEffect(() => {
+    const dx = x - prevRef.current.x;
+    const dy = y - prevRef.current.y;
+    prevRef.current = { x, y };
+    const s = Math.hypot(dx, dy);
+    if (s > 0.5) {
+      // Tail points opposite to the direction of travel
+      setAngle((Math.atan2(dy, dx) * 180) / Math.PI + 180);
+    }
+    setSpeed(s);
+  }, [x, y]);
+
+  const energy = Math.min(speed * 0.05, 1.5);
+
+  return (
+    <>
+      {/* Tail — rotates around its right tip which sits on the cursor point */}
+      <motion.div
+        className="fixed top-0 left-0 h-[7px] w-14 rounded-full pointer-events-none z-40"
+        style={{
+          x,
+          y,
+          translateX: "-100%",
+          translateY: "-50%",
+          transformOrigin: "right center",
+          background:
+            "linear-gradient(to left, rgba(251,146,60,0.95), rgba(251,146,60,0.35) 55%, transparent)",
+          filter: "blur(1.5px)",
+        }}
+        animate={{
+          rotate: angle,
+          scaleX: isStatic ? 0.7 : 0.35 + energy,
+          opacity: isStatic ? 0.8 : 0.35 + Math.min(speed * 0.04, 0.65),
+        }}
+        transition={{ type: "spring", stiffness: 240, damping: 24 }}
+      />
+      {/* White-hot head */}
+      <motion.div
+        className="fixed top-0 left-0 w-4 h-4 rounded-full pointer-events-none z-50"
+        style={{
+          x,
+          y,
+          translateX: "-50%",
+          translateY: "-50%",
+          background:
+            "radial-gradient(circle, #fff7ed 0%, #fdba74 45%, #ea580c 100%)",
+          boxShadow:
+            "0 0 18px rgba(251,146,60,0.85), 0 0 44px rgba(251,146,60,0.4)",
+        }}
+      />
+    </>
+  );
+}

--- a/src/registry/cursors/constellation.tsx
+++ b/src/registry/cursors/constellation.tsx
@@ -1,0 +1,112 @@
+"use client";
+
+import { motion } from "framer-motion";
+import { useEffect, useRef, useState } from "react";
+
+interface Star {
+  id: number;
+  x: number;
+  y: number;
+}
+
+// Static mini-constellation used for gallery previews
+const PREVIEW_STARS: Star[] = [
+  { id: -1, x: 0, y: 0 },
+  { id: -2, x: -14, y: -10 },
+  { id: -3, x: 12, y: -16 },
+  { id: -4, x: 16, y: 10 },
+  { id: -5, x: -10, y: 14 },
+];
+
+export default function ConstellationCursor({
+  x,
+  y,
+  isStatic,
+}: {
+  x: number;
+  y: number;
+  isStatic?: boolean;
+}) {
+  const [stars, setStars] = useState<Star[]>([]);
+  const idRef = useRef(0);
+
+  useEffect(() => {
+    if (isStatic) return;
+    setStars((prev) => [...prev.slice(-6), { id: idRef.current++, x, y }]);
+  }, [x, y, isStatic]);
+
+  const points = isStatic ? PREVIEW_STARS : stars;
+
+  return (
+    <>
+      {/* Connecting lines */}
+      <svg className="fixed top-0 left-0 w-full h-full pointer-events-none z-40">
+        {points.slice(1).map((p, i) => {
+          const prev = points[i];
+          return (
+            <line
+              key={p.id}
+              x1={prev.x}
+              y1={prev.y}
+              x2={p.x}
+              y2={p.y}
+              stroke="rgba(147,197,253,0.45)"
+              strokeWidth="1"
+            />
+          );
+        })}
+      </svg>
+
+      {/* Trailing stars */}
+      {points.slice(isStatic ? 0 : 1).map((p, i) => (
+        <motion.div
+          key={p.id}
+          className="fixed top-0 left-0 rounded-full pointer-events-none z-40 bg-sky-200"
+          style={{
+            x: p.x,
+            y: p.y,
+            translateX: "-50%",
+            translateY: "-50%",
+            width: 3,
+            height: 3,
+            boxShadow: "0 0 6px rgba(147,197,253,0.9)",
+          }}
+          initial={isStatic ? false : { opacity: 0.9, scale: 1 }}
+          animate={
+            isStatic ? { opacity: [0.3, 0.9, 0.3] } : { opacity: 0, scale: 0.4 }
+          }
+          transition={
+            isStatic
+              ? { duration: 1.8, repeat: Infinity, delay: i * 0.35 }
+              : { duration: 0.7, ease: "easeOut" }
+          }
+        />
+      ))}
+
+      {/* Leading north star */}
+      <motion.div
+        className="fixed top-0 left-0 pointer-events-none z-50"
+        style={{ x, y, translateX: "-50%", translateY: "-50%" }}
+      >
+        <svg width="18" height="18" viewBox="0 0 24 24">
+          <path
+            d="M12 0L14.5 9.5L24 12L14.5 14.5L12 24L9.5 14.5L0 12L9.5 9.5L12 0Z"
+            fill="url(#constellationGrad)"
+          />
+          <defs>
+            <linearGradient
+              id="constellationGrad"
+              x1="0%"
+              y1="0%"
+              x2="100%"
+              y2="100%"
+            >
+              <stop offset="0%" stopColor="#e0f2fe" />
+              <stop offset="100%" stopColor="#7dd3fc" />
+            </linearGradient>
+          </defs>
+        </svg>
+      </motion.div>
+    </>
+  );
+}

--- a/src/registry/cursors/crown.tsx
+++ b/src/registry/cursors/crown.tsx
@@ -1,49 +1,91 @@
 "use client";
+
 import { motion } from "framer-motion";
 
-export default function CrownCursor({ x, y }: { x: number; y: number }) {
+export default function CrownCursor({
+  x,
+  y,
+  isHovering,
+  isStatic,
+}: {
+  x: number;
+  y: number;
+  isHovering?: boolean;
+  isStatic?: boolean;
+}) {
   return (
     <motion.div
-      className="fixed top-0 left-0 pointer-events-none z-50 flex items-center justify-center"
+      className="fixed top-0 left-0 pointer-events-none z-50"
       style={{ x, y, translateX: "-50%", translateY: "-50%" }}
     >
       <motion.div
-        animate={{ y: [0, -3, 0] }}
-        transition={{ duration: 3, repeat: Infinity, ease: "easeInOut" }}
+        animate={{
+          y: isStatic ? 0 : [0, -3, 0],
+          rotate: isHovering ? -8 : 0,
+          scale: isHovering ? 1.1 : 1,
+        }}
+        transition={{
+          y: { duration: 3, repeat: Infinity, ease: "easeInOut" },
+          rotate: { type: "spring", stiffness: 300, damping: 18 },
+          scale: { type: "spring", stiffness: 300, damping: 18 },
+        }}
+        style={{ filter: "drop-shadow(0 0 8px rgba(250,204,21,0.4))" }}
       >
-        <svg
-          width="32"
-          height="32"
-          viewBox="0 0 24 24"
-          fill="none"
-          xmlns="http://www.w3.org/2000/svg"
-        >
+        <svg width="34" height="34" viewBox="0 0 24 24">
+          <defs>
+            <linearGradient id="crownGold" x1="0%" y1="0%" x2="0%" y2="100%">
+              <stop offset="0%" stopColor="#fde047" />
+              <stop offset="55%" stopColor="#eab308" />
+              <stop offset="100%" stopColor="#a16207" />
+            </linearGradient>
+          </defs>
+
+          {/* Crown body */}
           <path
             d="M5 16L3 5L8.5 10L12 4L15.5 10L21 5L19 16H5Z"
-            fill="#facc15"
-            stroke="#eab308"
-            strokeWidth="1.5"
+            fill="url(#crownGold)"
+            stroke="#a16207"
+            strokeWidth="1"
             strokeLinejoin="round"
           />
-          <path d="M5 16H19V19H5V16Z" fill="#eab308" />
+          {/* Base band */}
+          <path
+            d="M5 16H19V19H5V16Z"
+            fill="url(#crownGold)"
+            stroke="#a16207"
+            strokeWidth="0.8"
+          />
+          {/* Highlight */}
+          <path
+            d="M5.5 15.5 L4 7"
+            stroke="#fef9c3"
+            strokeWidth="0.8"
+            strokeLinecap="round"
+            opacity="0.7"
+          />
 
           {/* Gems */}
-          <circle cx="12" cy="13" r="1.5" fill="#ef4444">
-            <animate
-              attributeName="opacity"
-              values="1;0.5;1"
-              dur="2s"
-              repeatCount="indefinite"
-            />
-          </circle>
+          <motion.circle
+            cx="12"
+            cy="13"
+            r="1.5"
+            fill="#ef4444"
+            animate={isStatic ? {} : { opacity: [1, 0.5, 1] }}
+            transition={{ duration: 2, repeat: Infinity }}
+          />
           <circle cx="7" cy="13" r="1" fill="#3b82f6" />
           <circle cx="17" cy="13" r="1" fill="#3b82f6" />
+          <circle cx="12" cy="17.5" r="0.8" fill="#fef9c3" opacity="0.8" />
         </svg>
-        <motion.div
-          className="absolute -top-2 left-1/2 w-4 h-4 bg-yellow-200/50 rounded-full blur-md"
-          animate={{ opacity: [0, 0.5, 0] }}
-          transition={{ duration: 2, repeat: Infinity }}
-        />
+
+        {/* Royal aura */}
+        {!isStatic && (
+          <motion.div
+            className="absolute -top-2 left-1/2 -translate-x-1/2 w-5 h-5 bg-yellow-200/50 rounded-full blur-md"
+            animate={{ opacity: [0, 0.6, 0] }}
+            transition={{ duration: 2, repeat: Infinity }}
+          />
+        )}
       </motion.div>
     </motion.div>
   );

--- a/src/registry/cursors/eclipse.tsx
+++ b/src/registry/cursors/eclipse.tsx
@@ -1,0 +1,50 @@
+"use client";
+
+import { motion } from "framer-motion";
+
+export default function EclipseCursor({
+  x,
+  y,
+  isHovering,
+  isStatic,
+}: {
+  x: number;
+  y: number;
+  isHovering?: boolean;
+  isStatic?: boolean;
+}) {
+  return (
+    <motion.div
+      className="fixed top-0 left-0 pointer-events-none z-50"
+      style={{ x, y, translateX: "-50%", translateY: "-50%" }}
+    >
+      {/* Corona rays */}
+      <motion.div
+        className="absolute left-1/2 top-1/2 w-[46px] h-[46px] -translate-x-1/2 -translate-y-1/2 rounded-full"
+        style={{
+          background:
+            "conic-gradient(from 0deg, transparent 0deg, rgba(253,224,71,0.5) 12deg, transparent 24deg, transparent 90deg, rgba(253,224,71,0.4) 102deg, transparent 114deg, transparent 180deg, rgba(253,224,71,0.5) 192deg, transparent 204deg, transparent 270deg, rgba(253,224,71,0.4) 282deg, transparent 294deg)",
+          filter: "blur(3px)",
+        }}
+        animate={isStatic ? {} : { rotate: 360 }}
+        transition={{ duration: 26, repeat: Infinity, ease: "linear" }}
+      />
+
+      {/* Corona ring */}
+      <motion.div
+        className="absolute left-1/2 top-1/2 w-[30px] h-[30px] -translate-x-1/2 -translate-y-1/2 rounded-full"
+        style={{
+          boxShadow:
+            "0 0 14px rgba(253,224,71,0.85), 0 0 34px rgba(251,146,60,0.45), inset 0 0 6px rgba(253,224,71,0.5)",
+        }}
+        animate={
+          isStatic ? {} : { scale: isHovering ? [1, 1.12, 1] : [1, 1.05, 1] }
+        }
+        transition={{ duration: 2.6, repeat: Infinity, ease: "easeInOut" }}
+      />
+
+      {/* Occluding disc */}
+      <div className="absolute left-1/2 top-1/2 w-[24px] h-[24px] -translate-x-1/2 -translate-y-1/2 rounded-full bg-zinc-950 border border-yellow-200/60" />
+    </motion.div>
+  );
+}

--- a/src/registry/cursors/fireflies.tsx
+++ b/src/registry/cursors/fireflies.tsx
@@ -1,0 +1,104 @@
+"use client";
+
+import { motion, useMotionValue, useSpring } from "framer-motion";
+import type { MotionValue } from "framer-motion";
+import { useEffect } from "react";
+
+const FLIES = [
+  {
+    stiffness: 110,
+    damping: 14,
+    size: 7,
+    flicker: 1.6,
+    offsetX: 0,
+    offsetY: 0,
+  },
+  {
+    stiffness: 70,
+    damping: 12,
+    size: 5,
+    flicker: 2.2,
+    offsetX: 10,
+    offsetY: -8,
+  },
+  {
+    stiffness: 50,
+    damping: 10,
+    size: 4,
+    flicker: 1.3,
+    offsetX: -9,
+    offsetY: 9,
+  },
+];
+
+export default function FirefliesCursor({
+  x,
+  y,
+  isStatic,
+}: {
+  x: number;
+  y: number;
+  isStatic?: boolean;
+}) {
+  const mx = useMotionValue(x);
+  const my = useMotionValue(y);
+
+  useEffect(() => {
+    mx.set(x);
+    my.set(y);
+  }, [x, y, mx, my]);
+
+  return (
+    <>
+      {FLIES.map((fly, i) => (
+        <Firefly key={i} mx={mx} my={my} config={fly} isStatic={isStatic} />
+      ))}
+    </>
+  );
+}
+
+function Firefly({
+  mx,
+  my,
+  config,
+  isStatic,
+}: {
+  mx: MotionValue<number>;
+  my: MotionValue<number>;
+  config: (typeof FLIES)[number];
+  isStatic?: boolean;
+}) {
+  const fx = useSpring(mx, {
+    stiffness: config.stiffness,
+    damping: config.damping,
+  });
+  const fy = useSpring(my, {
+    stiffness: config.stiffness,
+    damping: config.damping,
+  });
+
+  return (
+    <motion.div
+      className="fixed top-0 left-0 rounded-full pointer-events-none z-50"
+      style={{
+        x: fx,
+        y: fy,
+        translateX: "-50%",
+        translateY: "-50%",
+        width: config.size,
+        height: config.size,
+        marginLeft: config.offsetX,
+        marginTop: config.offsetY,
+        background: "#fde68a",
+        boxShadow:
+          "0 0 10px rgba(253,230,138,0.9), 0 0 24px rgba(251,191,36,0.5)",
+      }}
+      animate={isStatic ? {} : { opacity: [0.35, 1, 0.5, 1, 0.35] }}
+      transition={{
+        duration: config.flicker,
+        repeat: Infinity,
+        ease: "easeInOut",
+      }}
+    />
+  );
+}

--- a/src/registry/cursors/flame.tsx
+++ b/src/registry/cursors/flame.tsx
@@ -1,96 +1,151 @@
 "use client";
-import { motion, AnimatePresence } from "framer-motion";
-import { useState, useEffect, useRef } from "react";
 
-interface FlameParticle {
+import { motion } from "framer-motion";
+import { useEffect, useRef, useState } from "react";
+
+interface Ember {
   id: number;
   x: number;
   y: number;
   size: number;
   color: string;
+  drift: number;
 }
 
 export default function FlameCursor({
   x,
   y,
+  isHovering,
   isStatic,
 }: {
   x: number;
   y: number;
+  isHovering?: boolean;
   isStatic?: boolean;
 }) {
-  const [particles, setParticles] = useState<FlameParticle[]>([]);
-  const idCounter = useRef(0);
+  const [embers, setEmbers] = useState<Ember[]>([]);
+  const idRef = useRef(0);
 
   useEffect(() => {
     if (isStatic) return;
     const interval = setInterval(() => {
-      const newParticle = {
-        id: idCounter.current++,
-        x: x + (Math.random() - 0.5) * 12,
-        y: y,
-        size: Math.random() * 8 + 4,
-        color: Math.random() > 0.3 ? "#f97316" : "#fbbf24", // orange or yellow
-      };
-      setParticles((prev) => [...prev.slice(-8), newParticle]); // Reduced from 12 to 8
-    }, 70); // Increased from 50ms to 70ms
+      setEmbers((prev) => [
+        ...prev.slice(-5),
+        {
+          id: idRef.current++,
+          x: x + (Math.random() - 0.5) * 10,
+          y: y - 8,
+          size: Math.random() * 3 + 1.5,
+          color: Math.random() > 0.4 ? "#fb923c" : "#fbbf24",
+          drift: (Math.random() - 0.5) * 14,
+        },
+      ]);
+    }, 120);
     return () => clearInterval(interval);
   }, [x, y, isStatic]);
 
   return (
     <>
-      <AnimatePresence>
-        {particles.map((p) => (
-          <motion.div
-            key={p.id}
-            className="fixed top-0 left-0 rounded-full pointer-events-none z-50"
-            style={{
-              width: p.size,
-              height: p.size * 1.4,
-              x: p.x,
-              y: p.y,
-              translateX: "-50%",
-              translateY: "-50%",
-              background: `radial-gradient(circle, ${p.color}, transparent)`,
-              filter: "blur(2px)",
-            }}
-            initial={{ opacity: 1, scale: 1, y: p.y }}
-            animate={{ opacity: 0, scale: 0.2, y: p.y - 40 }}
-            exit={{ opacity: 0 }}
-            transition={{ duration: 0.8, ease: "easeOut" }}
-          />
-        ))}
-      </AnimatePresence>
+      {/* Rising embers */}
+      {embers.map((e) => (
+        <motion.div
+          key={e.id}
+          className="fixed top-0 left-0 rounded-full pointer-events-none z-40"
+          style={{
+            x: e.x,
+            y: e.y,
+            translateX: "-50%",
+            translateY: "-50%",
+            width: e.size,
+            height: e.size,
+            background: e.color,
+            boxShadow: `0 0 6px ${e.color}`,
+          }}
+          initial={{ opacity: 0.9 }}
+          animate={{
+            opacity: 0,
+            y: e.y - 38,
+            x: e.x + e.drift,
+          }}
+          transition={{ duration: 0.85, ease: "easeOut" }}
+        />
+      ))}
+
+      {/* Warm ground glow */}
+      <motion.div
+        className="fixed top-0 left-0 w-[70px] h-[70px] rounded-full pointer-events-none z-40"
+        style={{
+          x,
+          y,
+          translateX: "-50%",
+          translateY: "-50%",
+          background:
+            "radial-gradient(circle, rgba(249,115,22,0.28) 0%, transparent 70%)",
+          filter: "blur(8px)",
+        }}
+        animate={isStatic ? {} : { opacity: [0.7, 1, 0.75, 1, 0.7] }}
+        transition={{ duration: 1.4, repeat: Infinity, ease: "easeInOut" }}
+      />
+
       <motion.div
         className="fixed top-0 left-0 pointer-events-none z-50"
         style={{ x, y, translateX: "-50%", translateY: "-50%" }}
       >
-        <svg
-          width="24"
-          height="32"
-          viewBox="0 0 24 32"
-          fill="none"
-          xmlns="http://www.w3.org/2000/svg"
+        <motion.div
+          style={{ transformOrigin: "50% 90%" }}
+          animate={{
+            scale: isHovering ? 1.15 : 1,
+            ...(isStatic
+              ? {}
+              : {
+                  scaleY: [1, 1.05, 0.96, 1.03, 1],
+                  skewX: [0, 1.6, -1.4, 0.8, 0],
+                }),
+          }}
+          transition={{
+            scale: { type: "spring", stiffness: 350, damping: 18 },
+            scaleY: { duration: 1.15, repeat: Infinity, ease: "easeInOut" },
+            skewX: { duration: 1.15, repeat: Infinity, ease: "easeInOut" },
+          }}
         >
-          <path
-            d="M12 32C18.6274 32 24 26.6274 24 20C24 13.3726 12 0 12 0C12 0 0 13.3726 0 20C0 26.6274 5.37258 32 12 32Z"
-            fill="url(#flame-grad)"
-          />
-          <defs>
-            <radialGradient
-              id="flame-grad"
-              cx="0"
-              cy="0"
-              r="1"
-              gradientUnits="userSpaceOnUse"
-              gradientTransform="translate(12 20) rotate(90) scale(12 12)"
-            >
-              <stop offset="0" stopColor="#fbbf24" />
-              <stop offset="0.6" stopColor="#f97316" />
-              <stop offset="1" stopColor="#dc2626" />
-            </radialGradient>
-          </defs>
-        </svg>
+          <svg
+            width="26"
+            height="34"
+            viewBox="0 0 24 32"
+            style={{
+              filter: "drop-shadow(0 0 10px rgba(249,115,22,0.5))",
+            }}
+          >
+            <defs>
+              <linearGradient id="flameOuter" x1="0%" y1="100%" x2="0%" y2="0%">
+                <stop offset="0%" stopColor="#dc2626" />
+                <stop offset="55%" stopColor="#f97316" />
+                <stop offset="100%" stopColor="#fb923c" />
+              </linearGradient>
+              <linearGradient id="flameMid" x1="0%" y1="100%" x2="0%" y2="0%">
+                <stop offset="0%" stopColor="#f97316" />
+                <stop offset="100%" stopColor="#fbbf24" />
+              </linearGradient>
+            </defs>
+
+            {/* Outer flame */}
+            <path
+              d="M12 31 C6.5 31 2.5 26.5 2.5 20 C2.5 14.5 6 11.5 8 6.5 C9.2 9.5 10.5 10.8 11.8 11.5 C11 7.5 12.5 3.5 15.5 1 C15 5 17 7.5 18.8 10 C21 13 21.5 16.5 21.5 20 C21.5 26.5 17.5 31 12 31 Z"
+              fill="url(#flameOuter)"
+            />
+            {/* Mid flame */}
+            <path
+              d="M12 28.5 C8.7 28.5 6.2 25.6 6.2 21.5 C6.2 18 8.4 15.6 10.2 12.2 C11 14.4 12 15.3 13.1 15.8 C12.6 13.2 14 10.6 15.9 9 C15.7 11.6 16.9 13.6 17.8 15.6 C18.9 18.2 17.9 21.5 17.9 21.5 C17.7 25.6 15.3 28.5 12 28.5 Z"
+              fill="url(#flameMid)"
+              opacity="0.95"
+            />
+            {/* White-hot core */}
+            <path
+              d="M12 26 C10.1 26 8.7 24.2 8.7 21.6 C8.7 19 10.2 17.3 12 14.6 C13.8 17.3 15.3 19 15.3 21.6 C15.3 24.2 13.9 26 12 26 Z"
+              fill="#fef3c7"
+            />
+          </svg>
+        </motion.div>
       </motion.div>
     </>
   );

--- a/src/registry/cursors/galaxy.tsx
+++ b/src/registry/cursors/galaxy.tsx
@@ -1,0 +1,83 @@
+"use client";
+
+import { motion } from "framer-motion";
+import { useMemo } from "react";
+
+const STAR_COLORS = ["#e0e7ff", "#c4b5fd", "#93c5fd", "#f0abfc"];
+
+export default function GalaxyCursor({
+  x,
+  y,
+  isStatic,
+}: {
+  x: number;
+  y: number;
+  isStatic?: boolean;
+}) {
+  // Two logarithmic spiral arms of stars
+  const stars = useMemo(() => {
+    const pts: {
+      cx: number;
+      cy: number;
+      r: number;
+      color: string;
+      opacity: number;
+    }[] = [];
+    for (let arm = 0; arm < 2; arm++) {
+      for (let i = 0; i < 9; i++) {
+        const t = i / 9;
+        const angle = arm * Math.PI + t * Math.PI * 1.7;
+        const radius = 3 + t * 15;
+        pts.push({
+          cx: 22 + Math.cos(angle) * radius,
+          cy: 22 + Math.sin(angle) * radius * 0.62,
+          r: 0.8 + (1 - t) * 1.1,
+          color: STAR_COLORS[(arm + i) % STAR_COLORS.length],
+          opacity: 0.5 + (1 - t) * 0.5,
+        });
+      }
+    }
+    return pts;
+  }, []);
+
+  return (
+    <motion.div
+      className="fixed top-0 left-0 pointer-events-none z-50"
+      style={{ x, y, translateX: "-50%", translateY: "-50%" }}
+    >
+      <motion.div
+        animate={isStatic ? {} : { rotate: 360 }}
+        transition={{ duration: 14, repeat: Infinity, ease: "linear" }}
+        style={{ filter: "drop-shadow(0 0 10px rgba(196,181,253,0.45))" }}
+      >
+        <svg width="44" height="44" viewBox="0 0 44 44">
+          <defs>
+            <radialGradient id="galaxyCore" cx="50%" cy="50%" r="50%">
+              <stop offset="0%" stopColor="#ffffff" />
+              <stop offset="45%" stopColor="#ddd6fe" />
+              <stop offset="100%" stopColor="#8b5cf6" stopOpacity="0" />
+            </radialGradient>
+          </defs>
+
+          {/* Core glow */}
+          <ellipse cx="22" cy="22" rx="9" ry="6" fill="url(#galaxyCore)" />
+
+          {/* Spiral arms */}
+          {stars.map((s, i) => (
+            <circle
+              key={i}
+              cx={s.cx}
+              cy={s.cy}
+              r={s.r}
+              fill={s.color}
+              opacity={s.opacity}
+            />
+          ))}
+        </svg>
+      </motion.div>
+
+      {/* Bright center */}
+      <div className="absolute left-1/2 top-1/2 w-1.5 h-1.5 -translate-x-1/2 -translate-y-1/2 rounded-full bg-white shadow-[0_0_10px_rgba(255,255,255,0.9)]" />
+    </motion.div>
+  );
+}

--- a/src/registry/cursors/goo.tsx
+++ b/src/registry/cursors/goo.tsx
@@ -1,0 +1,58 @@
+"use client";
+
+import { motion } from "framer-motion";
+import { useEffect, useRef, useState } from "react";
+
+export default function GooCursor({
+  x,
+  y,
+  isStatic,
+}: {
+  x: number;
+  y: number;
+  isStatic?: boolean;
+}) {
+  const [angle, setAngle] = useState(0);
+  const [stretch, setStretch] = useState(0);
+  const prevRef = useRef({ x, y });
+
+  useEffect(() => {
+    const dx = x - prevRef.current.x;
+    const dy = y - prevRef.current.y;
+    prevRef.current = { x, y };
+    const s = Math.hypot(dx, dy);
+    if (s > 0.5) setAngle((Math.atan2(dy, dx) * 180) / Math.PI);
+    setStretch(s);
+  }, [x, y]);
+
+  const pull = Math.min(stretch * 0.035, 1.3);
+
+  return (
+    <motion.div
+      className="fixed top-0 left-0 pointer-events-none z-50"
+      style={{ x, y, translateX: "-50%", translateY: "-50%" }}
+    >
+      {/* Elastic blob — stretches along the direction of travel */}
+      <motion.div
+        className="w-6 h-6 rounded-full"
+        style={{
+          background: "linear-gradient(135deg, #a855f7 0%, #ec4899 100%)",
+          boxShadow:
+            "0 0 20px rgba(168,85,247,0.55), 0 0 44px rgba(236,72,153,0.3)",
+          filter: "blur(0.5px)",
+        }}
+        animate={{
+          rotate: angle,
+          scaleX: isStatic ? 1 : 1 + pull,
+          scaleY: isStatic ? 1 : 1 - pull * 0.35,
+        }}
+        transition={{ type: "spring", stiffness: 280, damping: 16 }}
+      />
+      {/* Dense core */}
+      <motion.div
+        className="absolute left-1/2 top-1/2 w-2 h-2 rounded-full bg-white/90"
+        style={{ translateX: "-50%", translateY: "-50%" }}
+      />
+    </motion.div>
+  );
+}

--- a/src/registry/cursors/halo.tsx
+++ b/src/registry/cursors/halo.tsx
@@ -1,0 +1,53 @@
+"use client";
+
+import { motion, useMotionValue, useSpring } from "framer-motion";
+import { useEffect } from "react";
+
+export default function HaloCursor({
+  x,
+  y,
+  isHovering,
+}: {
+  x: number;
+  y: number;
+  isHovering?: boolean;
+}) {
+  const mx = useMotionValue(x);
+  const my = useMotionValue(y);
+
+  useEffect(() => {
+    mx.set(x);
+    my.set(y);
+  }, [x, y, mx, my]);
+
+  // The ring trails behind with a buttery spring
+  const ringX = useSpring(mx, { stiffness: 260, damping: 22, mass: 0.7 });
+  const ringY = useSpring(my, { stiffness: 260, damping: 22, mass: 0.7 });
+
+  return (
+    <>
+      {/* Lagging halo ring — adapts to light/dark via theme tokens */}
+      <motion.div
+        className="fixed top-0 left-0 rounded-full pointer-events-none z-40 border-[1.5px] border-foreground/70"
+        style={{
+          x: ringX,
+          y: ringY,
+          translateX: "-50%",
+          translateY: "-50%",
+          width: 34,
+          height: 34,
+        }}
+        animate={{
+          scale: isHovering ? 1.55 : 1,
+          opacity: isHovering ? 1 : 0.65,
+        }}
+        transition={{ type: "spring", stiffness: 320, damping: 20 }}
+      />
+      {/* Precise center dot */}
+      <motion.div
+        className="fixed top-0 left-0 w-1.5 h-1.5 rounded-full bg-foreground pointer-events-none z-50"
+        style={{ x, y, translateX: "-50%", translateY: "-50%" }}
+      />
+    </>
+  );
+}

--- a/src/registry/cursors/index.ts
+++ b/src/registry/cursors/index.ts
@@ -9,6 +9,34 @@ import GradientBlobCursor from "./gradient-blob";
 import LiquidMercuryCursor from "./liquid-mercury";
 import ParticleSwarmCursor from "./particle-swarm";
 import CyberScannerCursor from "./cyber-scanner";
+import AuroraCursor from "./aurora";
+import HaloCursor from "./halo";
+import CometCursor from "./comet";
+import SpotlightCursor from "./spotlight";
+import ChromaticCursor from "./chromatic";
+import LaserCursor from "./laser";
+import TerminalCursor from "./terminal";
+import GooCursor from "./goo";
+import FirefliesCursor from "./fireflies";
+import RadarCursor from "./radar";
+import ApertureCursor from "./aperture";
+import VortexCursor from "./vortex";
+import ConstellationCursor from "./constellation";
+import PaperPlaneCursor from "./paper-plane";
+import UfoCursor from "./ufo";
+import ButterflyCursor from "./butterfly";
+import MatrixCursor from "./matrix";
+import PrismCursor from "./prism";
+import GalaxyCursor from "./galaxy";
+import SaberCursor from "./saber";
+import InkCursor from "./ink";
+import VinylCursor from "./vinyl";
+import SakuraCursor from "./sakura";
+import LanternCursor from "./lantern";
+import EclipseCursor from "./eclipse";
+import PotionCursor from "./potion";
+import RibbonCursor from "./ribbon";
+import PlasmaCursor from "./plasma";
 
 // Minimal cursors
 import CircleCursor from "./circle";
@@ -190,6 +218,15 @@ export const CURSORS: CursorDefinition[] = [
     featured: true,
     code: { react: `// DotRing cursor`, vanilla: `// Pending` },
   },
+  {
+    id: "halo",
+    name: "Halo",
+    description: "Elegant lagging ring with precise dot",
+    tags: ["minimal", "premium"],
+    component: HaloCursor,
+    featured: true,
+    code: { react: `// Halo cursor`, vanilla: `// Pending` },
+  },
 
   // === EFFECT CATEGORY ===
   {
@@ -303,6 +340,107 @@ export const CURSORS: CursorDefinition[] = [
     component: CyberScannerCursor,
     featured: true,
     code: { react: `// Cyber Scanner cursor`, vanilla: `// Pending` },
+  },
+  {
+    id: "aurora",
+    name: "Aurora",
+    description: "Flowing northern-lights gradient wash",
+    tags: ["effect", "premium", "gradient", "dark-mode"],
+    component: AuroraCursor,
+    featured: true,
+    code: { react: `// Aurora cursor`, vanilla: `// Pending` },
+  },
+  {
+    id: "comet",
+    name: "Comet",
+    description: "Velocity-driven tail that follows your motion",
+    tags: ["effect", "motion", "premium"],
+    component: CometCursor,
+    featured: true,
+    code: { react: `// Comet cursor`, vanilla: `// Pending` },
+  },
+  {
+    id: "spotlight",
+    name: "Spotlight",
+    description: "Soft flashlight pool for dark interfaces",
+    tags: ["effect", "light", "dark-mode"],
+    component: SpotlightCursor,
+    featured: true,
+    code: { react: `// Spotlight cursor`, vanilla: `// Pending` },
+  },
+  {
+    id: "fireflies",
+    name: "Fireflies",
+    description: "Drifting glowing swarm with natural lag",
+    tags: ["effect", "nature", "particles"],
+    component: FirefliesCursor,
+    code: { react: `// Fireflies cursor`, vanilla: `// Pending` },
+  },
+  {
+    id: "radar",
+    name: "Radar",
+    description: "Sweeping sonar dish with ping rings",
+    tags: ["effect", "tech"],
+    component: RadarCursor,
+    code: { react: `// Radar cursor`, vanilla: `// Pending` },
+  },
+  {
+    id: "vortex",
+    name: "Vortex",
+    description: "Spinning two-tone energy swirl",
+    tags: ["effect", "abstract"],
+    component: VortexCursor,
+    code: { react: `// Vortex cursor`, vanilla: `// Pending` },
+  },
+  {
+    id: "constellation",
+    name: "Constellation",
+    description: "Connected star trail across the night sky",
+    tags: ["effect", "space"],
+    component: ConstellationCursor,
+    code: { react: `// Constellation cursor`, vanilla: `// Pending` },
+  },
+  {
+    id: "galaxy",
+    name: "Galaxy",
+    description: "Slow-spinning spiral star system",
+    tags: ["effect", "space", "premium"],
+    component: GalaxyCursor,
+    featured: true,
+    code: { react: `// Galaxy cursor`, vanilla: `// Pending` },
+  },
+  {
+    id: "eclipse",
+    name: "Eclipse",
+    description: "Solar corona ring around a dark disc",
+    tags: ["effect", "space", "dark-mode"],
+    component: EclipseCursor,
+    code: { react: `// Eclipse cursor`, vanilla: `// Pending` },
+  },
+  {
+    id: "ribbon",
+    name: "Ribbon",
+    description: "Flowing silk gradient trail",
+    tags: ["effect", "gradient", "colorful"],
+    component: RibbonCursor,
+    code: { react: `// Ribbon cursor`, vanilla: `// Pending` },
+  },
+  {
+    id: "plasma",
+    name: "Plasma",
+    description: "Tesla orb with arcing tendrils",
+    tags: ["effect", "energy", "premium"],
+    component: PlasmaCursor,
+    code: { react: `// Plasma cursor`, vanilla: `// Pending` },
+  },
+  {
+    id: "sakura",
+    name: "Sakura",
+    description: "Drifting cherry-blossom petals",
+    tags: ["effect", "nature", "particles"],
+    component: SakuraCursor,
+    featured: true,
+    code: { react: `// Sakura cursor`, vanilla: `// Pending` },
   },
 
   // === SHAPE CATEGORY ===
@@ -476,6 +614,63 @@ export const CURSORS: CursorDefinition[] = [
     featured: true,
     code: { react: `// Ghost cursor`, vanilla: `// Pending` },
   },
+  {
+    id: "paper-plane",
+    name: "Paper Plane",
+    description: "Banks and steers toward your movement",
+    tags: ["animated", "playful"],
+    component: PaperPlaneCursor,
+    code: { react: `// Paper Plane cursor`, vanilla: `// Pending` },
+  },
+  {
+    id: "ufo",
+    name: "UFO",
+    description: "Hovering saucer with tractor beam",
+    tags: ["animated", "fun", "space"],
+    component: UfoCursor,
+    code: { react: `// UFO cursor`, vanilla: `// Pending` },
+  },
+  {
+    id: "butterfly",
+    name: "Butterfly",
+    description: "Gentle wing-flapping morpho",
+    tags: ["animated", "nature"],
+    component: ButterflyCursor,
+    code: { react: `// Butterfly cursor`, vanilla: `// Pending` },
+  },
+  {
+    id: "saber",
+    name: "Saber",
+    description: "Glowing energy blade that follows your aim",
+    tags: ["animated", "fun", "glow"],
+    component: SaberCursor,
+    code: { react: `// Saber cursor`, vanilla: `// Pending` },
+  },
+  {
+    id: "vinyl",
+    name: "Vinyl",
+    description: "Spinning record with glossy grooves",
+    tags: ["animated", "music", "retro"],
+    component: VinylCursor,
+    code: { react: `// Vinyl cursor`, vanilla: `// Pending` },
+  },
+  {
+    id: "lantern",
+    name: "Lantern",
+    description: "Floating paper lantern with warm glow",
+    tags: ["animated", "calm", "warm"],
+    component: LanternCursor,
+    featured: true,
+    code: { react: `// Lantern cursor`, vanilla: `// Pending` },
+  },
+  {
+    id: "potion",
+    name: "Potion",
+    description: "Bubbling arcane elixir flask",
+    tags: ["animated", "magical", "fun"],
+    component: PotionCursor,
+    code: { react: `// Potion cursor`, vanilla: `// Pending` },
+  },
 
   // === CREATIVE CATEGORY ===
   {
@@ -542,6 +737,72 @@ export const CURSORS: CursorDefinition[] = [
     component: WandCursor,
     code: { react: `// Wand cursor`, vanilla: `// Pending` },
   },
+  {
+    id: "chromatic",
+    name: "Chromatic",
+    description: "RGB split ghosts with spring lag",
+    tags: ["creative", "premium", "colorful"],
+    component: ChromaticCursor,
+    featured: true,
+    code: { react: `// Chromatic cursor`, vanilla: `// Pending` },
+  },
+  {
+    id: "laser",
+    name: "Laser",
+    description: "Presentation-grade red laser pointer",
+    tags: ["creative", "precision"],
+    component: LaserCursor,
+    code: { react: `// Laser cursor`, vanilla: `// Pending` },
+  },
+  {
+    id: "terminal",
+    name: "Terminal",
+    description: "Blinking block caret for dev tools",
+    tags: ["creative", "dev", "typography"],
+    component: TerminalCursor,
+    code: { react: `// Terminal cursor`, vanilla: `// Pending` },
+  },
+  {
+    id: "goo",
+    name: "Goo",
+    description: "Elastic blob that stretches with velocity",
+    tags: ["creative", "playful", "fluid"],
+    component: GooCursor,
+    code: { react: `// Goo cursor`, vanilla: `// Pending` },
+  },
+  {
+    id: "aperture",
+    name: "Aperture",
+    description: "Mechanical camera iris blades",
+    tags: ["creative", "media"],
+    component: ApertureCursor,
+    code: { react: `// Aperture cursor`, vanilla: `// Pending` },
+  },
+  {
+    id: "matrix",
+    name: "Matrix",
+    description: "Falling glyphs from the machine world",
+    tags: ["creative", "cyberpunk", "dev"],
+    component: MatrixCursor,
+    code: { react: `// Matrix cursor`, vanilla: `// Pending` },
+  },
+  {
+    id: "prism",
+    name: "Prism",
+    description: "Light split into a rainbow fan",
+    tags: ["creative", "premium", "colorful"],
+    component: PrismCursor,
+    featured: true,
+    code: { react: `// Prism cursor`, vanilla: `// Pending` },
+  },
+  {
+    id: "ink",
+    name: "Ink",
+    description: "Calligraphy brush with tapered strokes",
+    tags: ["creative", "art", "minimal"],
+    component: InkCursor,
+    code: { react: `// Ink cursor`, vanilla: `// Pending` },
+  },
 
   // === SCIENCE CATEGORY ===
   {
@@ -582,7 +843,7 @@ export const CURSORS: CursorDefinition[] = [
   {
     id: "coffee",
     name: "Coffee",
-    description: "Steaming hot coffee",
+    description: "Steaming to-go cup with sleeve",
     tags: ["animated", "food"],
     component: CoffeeCursor,
     code: { react: `// Coffee cursor`, vanilla: `// Pending` },
@@ -616,7 +877,7 @@ export const CURSORS: CursorDefinition[] = [
   {
     id: "skull",
     name: "Skull",
-    description: "Glowing eyes skull",
+    description: "Obsidian skull with ember gaze",
     tags: ["animated", "dark"],
     component: SkullCursor,
     code: { react: `// Skull cursor`, vanilla: `// Pending` },
@@ -687,7 +948,7 @@ export const CURSORS: CursorDefinition[] = [
   {
     id: "key",
     name: "Key",
-    description: "Shimmering golden key",
+    description: "Ornate brass skeleton key",
     tags: ["animated", "security"],
     component: KeyCursor,
     code: { react: `// Key cursor`, vanilla: `// Pending` },
@@ -727,7 +988,7 @@ export const CURSORS: CursorDefinition[] = [
   {
     id: "flame",
     name: "Flame",
-    description: "Animated fire particles",
+    description: "Layered living fire with rising embers",
     tags: ["animated", "fire"],
     component: FlameCursor,
     code: { react: `// Flame cursor`, vanilla: `// Pending` },

--- a/src/registry/cursors/ink.tsx
+++ b/src/registry/cursors/ink.tsx
@@ -1,0 +1,64 @@
+"use client";
+
+import { motion } from "framer-motion";
+import { useEffect, useRef, useState } from "react";
+
+interface Point {
+  x: number;
+  y: number;
+  id: number;
+}
+
+const TRAIL = 14;
+
+export default function InkCursor({
+  x,
+  y,
+  isStatic,
+}: {
+  x: number;
+  y: number;
+  isStatic?: boolean;
+}) {
+  const [points, setPoints] = useState<Point[]>([]);
+  const idRef = useRef(0);
+
+  useEffect(() => {
+    if (isStatic) return;
+    setPoints((prev) => [
+      ...prev.slice(-(TRAIL - 1)),
+      { x, y, id: idRef.current++ },
+    ]);
+  }, [x, y, isStatic]);
+
+  return (
+    <>
+      {/* Calligraphy stroke — tapered segments between recent points */}
+      <svg className="fixed top-0 left-0 w-full h-full pointer-events-none z-40 overflow-visible">
+        {points.slice(1).map((p, i) => {
+          const prev = points[i];
+          const t = (i + 1) / points.length; // 0 (old) → 1 (new)
+          return (
+            <line
+              key={p.id}
+              x1={prev.x}
+              y1={prev.y}
+              x2={p.x}
+              y2={p.y}
+              stroke="currentColor"
+              strokeWidth={0.8 + t * 4.2}
+              strokeLinecap="round"
+              opacity={0.12 + t * 0.55}
+            />
+          );
+        })}
+      </svg>
+
+      {/* Brush tip */}
+      <motion.div
+        className="fixed top-0 left-0 w-[7px] h-[7px] rounded-full pointer-events-none z-50 bg-foreground"
+        style={{ x, y, translateX: "-50%", translateY: "-50%" }}
+      />
+    </>
+  );
+}

--- a/src/registry/cursors/key.tsx
+++ b/src/registry/cursors/key.tsx
@@ -1,53 +1,130 @@
 "use client";
+
 import { motion } from "framer-motion";
 
-export default function KeyCursor({ x, y }: { x: number; y: number }) {
+export default function KeyCursor({
+  x,
+  y,
+  isHovering,
+  isStatic,
+}: {
+  x: number;
+  y: number;
+  isHovering?: boolean;
+  isStatic?: boolean;
+}) {
   return (
     <motion.div
-      className="fixed top-0 left-0 pointer-events-none z-50 flex items-center justify-center"
+      className="fixed top-0 left-0 pointer-events-none z-50"
       style={{ x, y, translateX: "-50%", translateY: "-50%" }}
     >
       <motion.div
-        className="relative"
-        animate={{ rotate: [-5, 5, -5] }}
-        transition={{ duration: 4, repeat: Infinity, ease: "easeInOut" }}
+        animate={{
+          rotate: isHovering ? -25 : -45,
+          scale: isHovering ? 1.12 : 1,
+        }}
+        transition={{ type: "spring", stiffness: 260, damping: 18 }}
+        style={{
+          filter: "drop-shadow(0 0 8px rgba(251,191,36,0.45))",
+        }}
       >
-        <svg
-          width="40"
-          height="40"
-          viewBox="0 0 24 24"
-          fill="none"
-          xmlns="http://www.w3.org/2000/svg"
-        >
+        <svg width="38" height="38" viewBox="0 0 36 36">
           <defs>
-            <linearGradient id="gold-gradient" x1="0" y1="0" x2="1" y2="1">
-              <stop offset="0%" stopColor="#fcd34d" />
-              <stop offset="50%" stopColor="#d97706" />
-              <stop offset="100%" stopColor="#fcd34d" />
+            <linearGradient id="keyGold" x1="0%" y1="0%" x2="100%" y2="100%">
+              <stop offset="0%" stopColor="#fef3c7" />
+              <stop offset="45%" stopColor="#fbbf24" />
+              <stop offset="100%" stopColor="#b45309" />
             </linearGradient>
           </defs>
+
+          {/* Ornate bow (ring) */}
           <path
-            d="M21 2L11 12M11 12C11 14.2091 9.20914 16 7 16C4.79086 16 3 14.2091 3 12C3 9.79086 4.79086 8 7 8C8.34969 8 9.5312 8.667 10.2543 9.682M11 12L13 14L15 12L17 14L21 10V2H17L11 12Z"
-            stroke="url(#gold-gradient)"
-            strokeWidth="2.5"
-            strokeLinecap="round"
-            strokeLinejoin="round"
-            fill="rgba(251, 191, 36, 0.1)"
+            d="M9 11.5 A6 6 0 1 0 9 23.5 A6 6 0 1 0 9 11.5 Z M9 14.5 A3 3 0 1 1 9 20.5 A3 3 0 1 1 9 14.5 Z"
+            fill="url(#keyGold)"
+            fillRule="evenodd"
+            stroke="#92400e"
+            strokeWidth="0.5"
           />
-          <motion.circle
-            cx="7"
-            cy="12"
-            r="1.5"
-            fill="#fff"
-            animate={{ opacity: [0, 1, 0] }}
-            transition={{ duration: 2, repeat: Infinity }}
+          {/* Clover dots on the bow */}
+          <circle cx="9" cy="12.6" r="0.7" fill="#92400e" opacity="0.55" />
+          <circle cx="13.4" cy="17.5" r="0.7" fill="#92400e" opacity="0.55" />
+          <circle cx="9" cy="22.4" r="0.7" fill="#92400e" opacity="0.55" />
+          <circle cx="4.6" cy="17.5" r="0.7" fill="#92400e" opacity="0.55" />
+
+          {/* Shank */}
+          <rect
+            x="14.4"
+            y="16.6"
+            width="13.6"
+            height="2.2"
+            rx="1.1"
+            fill="url(#keyGold)"
+            stroke="#92400e"
+            strokeWidth="0.4"
           />
+          {/* Collars */}
+          <rect
+            x="16.4"
+            y="15.6"
+            width="1.5"
+            height="4.2"
+            rx="0.7"
+            fill="url(#keyGold)"
+            stroke="#92400e"
+            strokeWidth="0.4"
+          />
+          <rect
+            x="19.2"
+            y="16.1"
+            width="1"
+            height="3.2"
+            rx="0.5"
+            fill="url(#keyGold)"
+            stroke="#92400e"
+            strokeWidth="0.35"
+          />
+
+          {/* Bit teeth */}
+          <rect
+            x="25.6"
+            y="18.8"
+            width="2.6"
+            height="4.6"
+            rx="0.5"
+            fill="url(#keyGold)"
+            stroke="#92400e"
+            strokeWidth="0.4"
+          />
+          <rect
+            x="22.9"
+            y="18.8"
+            width="1.7"
+            height="3.1"
+            rx="0.5"
+            fill="url(#keyGold)"
+            stroke="#92400e"
+            strokeWidth="0.4"
+          />
+
+          {/* Traveling glint */}
+          {!isStatic && (
+            <motion.circle
+              r="1.1"
+              fill="#fffbeb"
+              style={{ filter: "drop-shadow(0 0 3px #fde68a)" }}
+              animate={{
+                cx: [16, 27, 16],
+                cy: [17.7, 17.7, 17.7],
+                opacity: [0, 1, 0],
+              }}
+              transition={{
+                duration: 2.4,
+                repeat: Infinity,
+                ease: "easeInOut",
+              }}
+            />
+          )}
         </svg>
-        <motion.div
-          className="absolute -top-1 -right-1 w-2 h-2 bg-yellow-200 rounded-full blur-[2px]"
-          animate={{ scale: [1, 1.5, 1], opacity: [0.5, 0.8, 0.5] }}
-          transition={{ duration: 1.5, repeat: Infinity }}
-        />
       </motion.div>
     </motion.div>
   );

--- a/src/registry/cursors/lantern.tsx
+++ b/src/registry/cursors/lantern.tsx
@@ -1,0 +1,118 @@
+"use client";
+
+import { motion } from "framer-motion";
+
+export default function LanternCursor({
+  x,
+  y,
+  isHovering,
+  isStatic,
+}: {
+  x: number;
+  y: number;
+  isHovering?: boolean;
+  isStatic?: boolean;
+}) {
+  return (
+    <motion.div
+      className="fixed top-0 left-0 pointer-events-none z-50"
+      style={{ x, y, translateX: "-50%", translateY: "-50%" }}
+    >
+      {/* Warm ambient glow */}
+      <motion.div
+        className="absolute left-1/2 top-1/2 w-[64px] h-[64px] -translate-x-1/2 -translate-y-1/2 rounded-full"
+        style={{
+          background:
+            "radial-gradient(circle, rgba(251,191,36,0.32) 0%, transparent 70%)",
+          filter: "blur(6px)",
+        }}
+        animate={isStatic ? {} : { opacity: [0.75, 1, 0.8, 1, 0.75] }}
+        transition={{ duration: 2.2, repeat: Infinity, ease: "easeInOut" }}
+      />
+
+      <motion.div
+        animate={{
+          y: isStatic ? 0 : [0, -4, 0],
+          rotate: isHovering ? 5 : 0,
+        }}
+        transition={{
+          y: { duration: 3, repeat: Infinity, ease: "easeInOut" },
+          rotate: { type: "spring", stiffness: 260, damping: 16 },
+        }}
+      >
+        <svg width="26" height="34" viewBox="0 0 26 34">
+          <defs>
+            <radialGradient id="lanternPaper" cx="50%" cy="42%" r="65%">
+              <stop offset="0%" stopColor="#fde68a" />
+              <stop offset="60%" stopColor="#f59e0b" />
+              <stop offset="100%" stopColor="#d97706" />
+            </radialGradient>
+          </defs>
+
+          {/* Hanging string */}
+          <path d="M13 0 V4" stroke="#a16207" strokeWidth="1" />
+          {/* Top cap */}
+          <rect x="9" y="4" width="8" height="2.4" rx="1" fill="#78350f" />
+          {/* Paper body */}
+          <ellipse
+            cx="13"
+            cy="17"
+            rx="10"
+            ry="11"
+            fill="url(#lanternPaper)"
+            stroke="#b45309"
+            strokeWidth="0.75"
+          />
+          {/* Ribs */}
+          <ellipse
+            cx="13"
+            cy="17"
+            rx="6.5"
+            ry="11"
+            fill="none"
+            stroke="#b45309"
+            strokeWidth="0.5"
+            opacity="0.55"
+          />
+          <ellipse
+            cx="13"
+            cy="17"
+            rx="3"
+            ry="11"
+            fill="none"
+            stroke="#b45309"
+            strokeWidth="0.5"
+            opacity="0.55"
+          />
+          <path
+            d="M3.6 13.5 H22.4 M3.6 20.5 H22.4"
+            stroke="#b45309"
+            strokeWidth="0.5"
+            opacity="0.45"
+          />
+          {/* Inner flame shimmer */}
+          {!isStatic && (
+            <motion.ellipse
+              cx="13"
+              cy="18"
+              rx="4"
+              ry="5.5"
+              fill="#fef3c7"
+              animate={{ opacity: [0.35, 0.7, 0.4, 0.65, 0.35] }}
+              transition={{ duration: 1.6, repeat: Infinity }}
+            />
+          )}
+          {/* Bottom cap + tassel */}
+          <rect x="9.5" y="27" width="7" height="2.2" rx="1" fill="#78350f" />
+          <path
+            d="M13 29.5 C12.4 31 13.6 32.2 13 33.5"
+            stroke="#dc2626"
+            strokeWidth="1.2"
+            strokeLinecap="round"
+            fill="none"
+          />
+        </svg>
+      </motion.div>
+    </motion.div>
+  );
+}

--- a/src/registry/cursors/laser.tsx
+++ b/src/registry/cursors/laser.tsx
@@ -1,0 +1,49 @@
+"use client";
+
+import { motion } from "framer-motion";
+
+export default function LaserCursor({
+  x,
+  y,
+  isHovering,
+  isStatic,
+}: {
+  x: number;
+  y: number;
+  isHovering?: boolean;
+  isStatic?: boolean;
+}) {
+  return (
+    <motion.div
+      className="fixed top-0 left-0 pointer-events-none z-50"
+      style={{ x, y }}
+    >
+      {/* Crosshair lines */}
+      <div className="absolute left-1/2 top-1/2 -translate-x-1/2 -translate-y-1/2 w-[26px] h-px bg-red-500/70" />
+      <div className="absolute left-1/2 top-1/2 -translate-x-1/2 -translate-y-1/2 h-[26px] w-px bg-red-500/70" />
+
+      {/* Expanding ping ring */}
+      {!isStatic && (
+        <motion.div
+          className="absolute left-1/2 top-1/2 w-8 h-8 rounded-full border border-red-500/60"
+          style={{ translateX: "-50%", translateY: "-50%" }}
+          animate={{ scale: [0.4, 1.4], opacity: [0.9, 0] }}
+          transition={{ duration: 1.6, repeat: Infinity, ease: "easeOut" }}
+        />
+      )}
+
+      {/* Laser dot */}
+      <motion.div
+        className="absolute left-1/2 top-1/2 w-2 h-2 rounded-full bg-red-500"
+        style={{
+          translateX: "-50%",
+          translateY: "-50%",
+          boxShadow:
+            "0 0 10px rgba(239,68,68,0.9), 0 0 26px rgba(239,68,68,0.55), 0 0 48px rgba(239,68,68,0.3)",
+        }}
+        animate={{ scale: isHovering ? 1.5 : 1 }}
+        transition={{ type: "spring", stiffness: 500, damping: 22 }}
+      />
+    </motion.div>
+  );
+}

--- a/src/registry/cursors/lock.tsx
+++ b/src/registry/cursors/lock.tsx
@@ -1,46 +1,94 @@
 "use client";
+
 import { motion } from "framer-motion";
 
-export default function LockCursor({ x, y }: { x: number; y: number }) {
+export default function LockCursor({
+  x,
+  y,
+  isHovering,
+  isStatic,
+}: {
+  x: number;
+  y: number;
+  isHovering?: boolean;
+  isStatic?: boolean;
+}) {
   return (
     <motion.div
-      className="fixed top-0 left-0 pointer-events-none z-50 flex items-center justify-center"
+      className="fixed top-0 left-0 pointer-events-none z-50"
       style={{ x, y, translateX: "-50%", translateY: "-50%" }}
     >
-      <div className="relative">
-        <motion.div
-          className="absolute inset-0 bg-slate-400/10 blur-md rounded-full"
-          animate={{ scale: [1, 1.3, 1] }}
-          transition={{ duration: 3, repeat: Infinity }}
-        />
-        <svg
-          width="32"
-          height="32"
-          viewBox="0 0 24 24"
-          fill="none"
-          xmlns="http://www.w3.org/2000/svg"
-        >
+      <motion.div
+        animate={{ scale: isHovering ? 1.1 : 1 }}
+        transition={{ type: "spring", stiffness: 320, damping: 18 }}
+        style={{ filter: "drop-shadow(0 0 8px rgba(100,116,139,0.45))" }}
+      >
+        <svg width="32" height="32" viewBox="0 0 24 24">
+          <defs>
+            <linearGradient id="lockBody" x1="0%" y1="0%" x2="0%" y2="100%">
+              <stop offset="0%" stopColor="#e2e8f0" />
+              <stop offset="50%" stopColor="#94a3b8" />
+              <stop offset="100%" stopColor="#64748b" />
+            </linearGradient>
+            <linearGradient id="lockShackle" x1="0%" y1="0%" x2="0%" y2="100%">
+              <stop offset="0%" stopColor="#cbd5e1" />
+              <stop offset="100%" stopColor="#64748b" />
+            </linearGradient>
+          </defs>
+
+          {/* Shackle — lifts teasingly on hover */}
+          <motion.path
+            d="M7 11V7C7 4.23858 9.23858 2 12 2C14.7614 2 17 4.23858 17 7V11"
+            stroke="url(#lockShackle)"
+            strokeWidth="2.4"
+            strokeLinecap="round"
+            fill="none"
+            animate={{ y: isHovering ? -1.6 : 0 }}
+            transition={{ type: "spring", stiffness: 400, damping: 20 }}
+          />
+
+          {/* Body */}
           <rect
             x="5"
             y="11"
             width="14"
             height="10"
             rx="2"
-            stroke="currentColor"
-            strokeWidth="2"
+            fill="url(#lockBody)"
+            stroke="#475569"
+            strokeWidth="0.75"
           />
-          <motion.path
-            d="M7 11V7C7 4.23858 9.23858 2 12 2C14.7614 2 17 4.23858 17 7V11"
-            stroke="currentColor"
-            strokeWidth="2"
+          {/* Body highlight */}
+          <path
+            d="M6.5 12.5 H17.5"
+            stroke="#f8fafc"
+            strokeWidth="0.8"
             strokeLinecap="round"
-            initial={{ pathLength: 1 }}
-            animate={{ y: [0, 1, 0] }}
-            transition={{ duration: 2, repeat: Infinity }}
+            opacity="0.6"
           />
-          <circle cx="12" cy="16" r="1.5" fill="currentColor" />
+
+          {/* Keyhole */}
+          <circle cx="12" cy="15.5" r="1.6" fill="#1e293b" />
+          <path
+            d="M12 15.5 L11 19 H13 L12 15.5"
+            fill="#1e293b"
+            stroke="#1e293b"
+            strokeWidth="0.5"
+            strokeLinejoin="round"
+          />
+          {/* Keyhole glow */}
+          {!isStatic && (
+            <motion.circle
+              cx="12"
+              cy="15.5"
+              r="0.7"
+              fill="#34d399"
+              animate={{ opacity: [0.2, 1, 0.2] }}
+              transition={{ duration: 2.4, repeat: Infinity }}
+            />
+          )}
         </svg>
-      </div>
+      </motion.div>
     </motion.div>
   );
 }

--- a/src/registry/cursors/matrix.tsx
+++ b/src/registry/cursors/matrix.tsx
@@ -1,0 +1,79 @@
+"use client";
+
+import { motion } from "framer-motion";
+import { useEffect, useRef, useState } from "react";
+
+const GLYPHS = "アカサタナハマヤラワガザダバパ0123456789$#+*<>";
+
+interface Drop {
+  id: number;
+  char: string;
+  x: number;
+  y: number;
+}
+
+export default function MatrixCursor({
+  x,
+  y,
+  isStatic,
+}: {
+  x: number;
+  y: number;
+  isStatic?: boolean;
+}) {
+  const [drops, setDrops] = useState<Drop[]>([]);
+  const idRef = useRef(0);
+
+  useEffect(() => {
+    if (isStatic) return;
+    const interval = setInterval(() => {
+      setDrops((prev) => [
+        ...prev.slice(-9),
+        {
+          id: idRef.current++,
+          char: GLYPHS[Math.floor(Math.random() * GLYPHS.length)],
+          x: x + (Math.random() - 0.5) * 28,
+          y: y - 6,
+        },
+      ]);
+    }, 90);
+    return () => clearInterval(interval);
+  }, [x, y, isStatic]);
+
+  return (
+    <>
+      {/* Falling glyphs */}
+      {drops.map((d) => (
+        <motion.span
+          key={d.id}
+          className="fixed top-0 left-0 pointer-events-none z-40 font-mono text-[11px] font-bold text-emerald-400"
+          style={{
+            x: d.x,
+            y: d.y,
+            translateX: "-50%",
+            translateY: "-50%",
+            textShadow: "0 0 6px rgba(52,211,153,0.8)",
+          }}
+          initial={{ opacity: 1 }}
+          animate={{ opacity: 0, y: d.y + 54 }}
+          transition={{ duration: 0.75, ease: "easeIn" }}
+        />
+      ))}
+
+      {/* Lead glyph core */}
+      <motion.div
+        className="fixed top-0 left-0 pointer-events-none z-50 font-mono text-sm font-black text-emerald-300"
+        style={{
+          x,
+          y,
+          translateX: "-50%",
+          translateY: "-50%",
+          textShadow:
+            "0 0 8px rgba(52,211,153,0.9), 0 0 20px rgba(52,211,153,0.5)",
+        }}
+      >
+        {isStatic ? "ア" : "0"}
+      </motion.div>
+    </>
+  );
+}

--- a/src/registry/cursors/paper-plane.tsx
+++ b/src/registry/cursors/paper-plane.tsx
@@ -1,0 +1,62 @@
+"use client";
+
+import { motion } from "framer-motion";
+import { useEffect, useRef, useState } from "react";
+
+export default function PaperPlaneCursor({ x, y }: { x: number; y: number }) {
+  const [angle, setAngle] = useState(-45);
+  const prevRef = useRef({ x, y });
+
+  useEffect(() => {
+    const dx = x - prevRef.current.x;
+    const dy = y - prevRef.current.y;
+    prevRef.current = { x, y };
+    if (Math.hypot(dx, dy) > 0.5) {
+      // Plane artwork points right at 0deg
+      setAngle((Math.atan2(dy, dx) * 180) / Math.PI);
+    }
+  }, [x, y]);
+
+  return (
+    <motion.div
+      className="fixed top-0 left-0 pointer-events-none z-50"
+      style={{ x, y, translateX: "-50%", translateY: "-50%" }}
+    >
+      <motion.div
+        animate={{ rotate: angle }}
+        transition={{ type: "spring", stiffness: 200, damping: 18 }}
+        style={{
+          filter: "drop-shadow(0 0 10px rgba(56,189,248,0.45))",
+        }}
+      >
+        <svg width="26" height="26" viewBox="0 0 24 24">
+          <path
+            d="M22.5 1.5L1.8 9.7c-.9.35-.8 1.6.15 1.85l7.4 2.1 2.1 7.4c.25.95 1.5 1.05 1.85.15l8.2-20.7c.35-.9-.5-1.75-1-1Z"
+            fill="url(#paperPlaneGrad)"
+            stroke="rgba(255,255,255,0.65)"
+            strokeWidth="0.6"
+            strokeLinejoin="round"
+          />
+          <path
+            d="M22.5 1.5L9.35 13.65"
+            stroke="rgba(255,255,255,0.7)"
+            strokeWidth="0.7"
+            fill="none"
+          />
+          <defs>
+            <linearGradient
+              id="paperPlaneGrad"
+              x1="0%"
+              y1="0%"
+              x2="100%"
+              y2="100%"
+            >
+              <stop offset="0%" stopColor="#7dd3fc" />
+              <stop offset="100%" stopColor="#38bdf8" />
+            </linearGradient>
+          </defs>
+        </svg>
+      </motion.div>
+    </motion.div>
+  );
+}

--- a/src/registry/cursors/pizza.tsx
+++ b/src/registry/cursors/pizza.tsx
@@ -1,67 +1,127 @@
 "use client";
+
 import { motion } from "framer-motion";
 
-export default function PizzaCursor({ x, y }: { x: number; y: number }) {
+export default function PizzaCursor({
+  x,
+  y,
+  isHovering,
+  isStatic,
+}: {
+  x: number;
+  y: number;
+  isHovering?: boolean;
+  isStatic?: boolean;
+}) {
   return (
     <motion.div
-      className="fixed top-0 left-0 pointer-events-none z-50 pointer-events-none"
-      style={{ x, y, translateX: "-50%", translateY: "-50%", rotate: -15 }}
+      className="fixed top-0 left-0 pointer-events-none z-50"
+      style={{ x, y, translateX: "-50%", translateY: "-50%" }}
     >
-      <div className="relative">
-        {/* Steam */}
-        {[0, 1, 2].map((i) => (
+      {/* Steam */}
+      {!isStatic &&
+        [0, 1, 2].map((i) => (
           <motion.div
             key={i}
-            className="absolute -top-4 left-4 w-1 h-3 bg-white/30 blur-[1.5px] rounded-full"
+            className="absolute w-[3px] h-[9px] bg-white/35 blur-[1.5px] rounded-full"
+            style={{ left: 12 + i * 6, top: -10 }}
             animate={{
-              opacity: [0, 0.4, 0],
-              y: [-5, -20],
-              x: [0, (i - 1) * 5],
-              scale: [0.5, 1.5],
+              opacity: [0, 0.5, 0],
+              y: [-3, -16],
+              x: [0, (i - 1) * 4],
             }}
             transition={{ duration: 1.5, repeat: Infinity, delay: i * 0.4 }}
           />
         ))}
 
-        <svg
-          width="40"
-          height="40"
-          viewBox="0 0 40 40"
-          fill="none"
-          xmlns="http://www.w3.org/2000/svg"
-        >
-          {/* Pizza Crust (Triangle Base) */}
+      <motion.div
+        animate={{
+          rotate: isHovering ? -22 : -15,
+          scale: isHovering ? 1.08 : 1,
+        }}
+        transition={{ type: "spring", stiffness: 300, damping: 18 }}
+        style={{ filter: "drop-shadow(0 0 8px rgba(245,158,11,0.35))" }}
+      >
+        <svg width="40" height="40" viewBox="0 0 40 40">
+          <defs>
+            <linearGradient
+              id="pizzaCheese"
+              x1="0%"
+              y1="0%"
+              x2="100%"
+              y2="100%"
+            >
+              <stop offset="0%" stopColor="#fde68a" />
+              <stop offset="100%" stopColor="#f59e0b" />
+            </linearGradient>
+            <radialGradient id="pizzaPep" cx="35%" cy="35%" r="80%">
+              <stop offset="0%" stopColor="#f87171" />
+              <stop offset="100%" stopColor="#b91c1c" />
+            </radialGradient>
+          </defs>
+
+          {/* Cheese base */}
           <path
             d="M5 5 L35 15 L15 35 Z"
-            fill="#fbbf24" // Cheese color
-            stroke="#92400e" // Crust outline
-            strokeWidth="1.5"
+            fill="url(#pizzaCheese)"
+            stroke="#92400e"
+            strokeWidth="1.2"
             strokeLinejoin="round"
           />
-
-          {/* Thick Crust Edge */}
+          {/* Thick crust */}
           <path
             d="M5 5 L35 15"
-            stroke="#78350f"
-            strokeWidth="4"
+            stroke="#b45309"
+            strokeWidth="4.5"
+            strokeLinecap="round"
+          />
+          <path
+            d="M5 5 L35 15"
+            stroke="#d97706"
+            strokeWidth="2"
             strokeLinecap="round"
           />
 
-          {/* Pepperonis */}
-          <circle cx="15" cy="15" r="3" fill="#dc2626" />
-          <circle cx="22" cy="20" r="2.5" fill="#ef4444" />
-          <circle cx="18" cy="27" r="2" fill="#b91c1c" />
-
-          {/* Melted patches */}
+          {/* Cheese drip at the tip */}
           <path
-            d="M12 20 Q15 22 18 18"
+            d="M15 35 C15.8 33 16.4 33 16.8 34.2 C16.5 35.6 15.4 35.8 15 35 Z"
+            fill="#f59e0b"
+          />
+
+          {/* Pepperoni */}
+          <circle cx="15" cy="15" r="3" fill="url(#pizzaPep)" />
+          <circle cx="23" cy="20" r="2.5" fill="url(#pizzaPep)" />
+          <circle cx="17.5" cy="26" r="2" fill="url(#pizzaPep)" />
+
+          {/* Basil */}
+          <ellipse
+            cx="20"
+            cy="12"
+            rx="2.2"
+            ry="1.2"
+            fill="#16a34a"
+            transform="rotate(-24 20 12)"
+          />
+          <ellipse
+            cx="12.5"
+            cy="21"
+            rx="1.8"
+            ry="1"
+            fill="#15803d"
+            transform="rotate(30 12.5 21)"
+          />
+
+          {/* Melted sheen */}
+          <path
+            d="M12 19 Q15 21 18 17"
             stroke="#fef3c7"
             strokeWidth="1"
             strokeLinecap="round"
-            opacity="0.6"
+            opacity="0.7"
+            fill="none"
           />
         </svg>
-      </div>
+      </motion.div>
     </motion.div>
   );
 }

--- a/src/registry/cursors/plasma.tsx
+++ b/src/registry/cursors/plasma.tsx
@@ -1,0 +1,90 @@
+"use client";
+
+import { motion } from "framer-motion";
+import { useMemo } from "react";
+
+export default function PlasmaCursor({
+  x,
+  y,
+  isHovering,
+  isStatic,
+}: {
+  x: number;
+  y: number;
+  isHovering?: boolean;
+  isStatic?: boolean;
+}) {
+  // Jagged electric tendrils radiating from the core.
+  // Jitter is deterministic (derived from index) to keep render pure.
+  const tendrils = useMemo(() => {
+    const jitter = (seed: number) => ((seed * 2654435761) % 100) / 100 - 0.5;
+    return [0, 60, 130, 200, 280].map((deg, i) => {
+      const rad = (deg * Math.PI) / 180;
+      const mid1 = {
+        x: 17 + Math.cos(rad) * 7 + jitter(i * 3 + 1) * 4,
+        y: 17 + Math.sin(rad) * 7 + jitter(i * 3 + 2) * 4,
+      };
+      const reach = 13 + jitter(i * 3 + 3) * 4;
+      const end = {
+        x: 17 + Math.cos(rad) * reach,
+        y: 17 + Math.sin(rad) * reach,
+      };
+      return `M17 17 L${mid1.x.toFixed(1)} ${mid1.y.toFixed(1)} L${end.x.toFixed(1)} ${end.y.toFixed(1)}`;
+    });
+  }, []);
+
+  return (
+    <motion.div
+      className="fixed top-0 left-0 pointer-events-none z-50"
+      style={{ x, y, translateX: "-50%", translateY: "-50%" }}
+    >
+      <motion.div
+        animate={{ scale: isHovering ? 1.15 : 1 }}
+        transition={{ type: "spring", stiffness: 320, damping: 16 }}
+        style={{ filter: "drop-shadow(0 0 10px rgba(192,132,252,0.6))" }}
+      >
+        <svg width="34" height="34" viewBox="0 0 34 34">
+          <defs>
+            <radialGradient id="plasmaCore" cx="50%" cy="50%" r="50%">
+              <stop offset="0%" stopColor="#faf5ff" />
+              <stop offset="45%" stopColor="#d8b4fe" />
+              <stop offset="100%" stopColor="#9333ea" />
+            </radialGradient>
+          </defs>
+
+          {/* Tendrils */}
+          {tendrils.map((d, i) => (
+            <motion.path
+              key={i}
+              d={d}
+              stroke="#c084fc"
+              strokeWidth="1"
+              strokeLinecap="round"
+              fill="none"
+              animate={isStatic ? {} : { opacity: [0.15, 0.9, 0.2] }}
+              transition={{
+                duration: 0.7 + i * 0.13,
+                repeat: Infinity,
+                delay: i * 0.11,
+              }}
+            />
+          ))}
+
+          {/* Orb */}
+          <circle cx="17" cy="17" r="6.5" fill="url(#plasmaCore)" />
+          <circle
+            cx="17"
+            cy="17"
+            r="6.5"
+            fill="none"
+            stroke="#e9d5ff"
+            strokeWidth="0.5"
+            opacity="0.8"
+          />
+          {/* Specular */}
+          <circle cx="15" cy="15" r="1.6" fill="#ffffff" opacity="0.9" />
+        </svg>
+      </motion.div>
+    </motion.div>
+  );
+}

--- a/src/registry/cursors/potion.tsx
+++ b/src/registry/cursors/potion.tsx
@@ -1,0 +1,95 @@
+"use client";
+
+import { motion } from "framer-motion";
+
+export default function PotionCursor({
+  x,
+  y,
+  isHovering,
+  isStatic,
+}: {
+  x: number;
+  y: number;
+  isHovering?: boolean;
+  isStatic?: boolean;
+}) {
+  return (
+    <motion.div
+      className="fixed top-0 left-0 pointer-events-none z-50"
+      style={{ x, y, translateX: "-50%", translateY: "-50%" }}
+    >
+      <motion.div
+        animate={{
+          rotate: isHovering ? -8 : 0,
+          scale: isHovering ? 1.1 : 1,
+        }}
+        transition={{ type: "spring", stiffness: 300, damping: 16 }}
+        style={{ filter: "drop-shadow(0 0 10px rgba(168,85,247,0.5))" }}
+      >
+        <svg width="28" height="36" viewBox="0 0 28 36">
+          <defs>
+            <linearGradient id="potionLiquid" x1="0%" y1="0%" x2="0%" y2="100%">
+              <stop offset="0%" stopColor="#c084fc" />
+              <stop offset="100%" stopColor="#7e22ce" />
+            </linearGradient>
+            <linearGradient
+              id="potionGlass"
+              x1="0%"
+              y1="0%"
+              x2="100%"
+              y2="100%"
+            >
+              <stop offset="0%" stopColor="#e9d5ff" stopOpacity="0.85" />
+              <stop offset="100%" stopColor="#a855f7" stopOpacity="0.35" />
+            </linearGradient>
+          </defs>
+
+          {/* Cork */}
+          <rect x="11" y="1" width="6" height="5" rx="1.2" fill="#92400e" />
+          {/* Neck */}
+          <path
+            d="M11.5 6 L11.5 12 L5 22 A9.5 9.5 0 1 0 23 22 L16.5 12 L16.5 6 Z"
+            fill="url(#potionGlass)"
+            stroke="#d8b4fe"
+            strokeWidth="0.75"
+          />
+          {/* Liquid */}
+          <path
+            d="M7.2 20.5 L5.6 22.6 A9 9 0 1 0 22.4 22.6 L20.8 20.5 C18.5 19 16 21.8 13.5 20.6 C11 19.4 9.5 19 7.2 20.5 Z"
+            fill="url(#potionLiquid)"
+          />
+          {/* Rising bubbles */}
+          {!isStatic && (
+            <>
+              {[9.5, 13.5, 17.5].map((cx, i) => (
+                <motion.circle
+                  key={cx}
+                  cx={cx}
+                  cy="27"
+                  r={0.9 + i * 0.25}
+                  fill="#e9d5ff"
+                  animate={{ cy: [27, 21], opacity: [0, 0.9, 0] }}
+                  transition={{
+                    duration: 1.3,
+                    repeat: Infinity,
+                    delay: i * 0.4,
+                    ease: "easeOut",
+                  }}
+                />
+              ))}
+            </>
+          )}
+          {/* Glass shine */}
+          <path
+            d="M8.5 15.5 C7 18 6.4 20.5 6.8 23"
+            stroke="#faf5ff"
+            strokeWidth="1"
+            strokeLinecap="round"
+            opacity="0.7"
+            fill="none"
+          />
+        </svg>
+      </motion.div>
+    </motion.div>
+  );
+}

--- a/src/registry/cursors/prism.tsx
+++ b/src/registry/cursors/prism.tsx
@@ -1,0 +1,103 @@
+"use client";
+
+import { motion } from "framer-motion";
+
+const SPECTRUM = [
+  "#ef4444",
+  "#f59e0b",
+  "#facc15",
+  "#22c55e",
+  "#3b82f6",
+  "#8b5cf6",
+];
+
+export default function PrismCursor({
+  x,
+  y,
+  isHovering,
+  isStatic,
+}: {
+  x: number;
+  y: number;
+  isHovering?: boolean;
+  isStatic?: boolean;
+}) {
+  return (
+    <motion.div
+      className="fixed top-0 left-0 pointer-events-none z-50"
+      style={{ x, y, translateX: "-50%", translateY: "-50%" }}
+    >
+      <motion.div
+        animate={{
+          rotate: isHovering ? 8 : 0,
+          scale: isHovering ? 1.1 : 1,
+        }}
+        transition={{ type: "spring", stiffness: 280, damping: 18 }}
+      >
+        <svg
+          width="44"
+          height="36"
+          viewBox="0 0 44 36"
+          style={{ filter: "drop-shadow(0 0 8px rgba(139,92,246,0.35))" }}
+        >
+          <defs>
+            <linearGradient id="prismGlass" x1="0%" y1="0%" x2="100%" y2="100%">
+              <stop offset="0%" stopColor="#e0e7ff" stopOpacity="0.9" />
+              <stop offset="100%" stopColor="#6366f1" stopOpacity="0.55" />
+            </linearGradient>
+          </defs>
+
+          {/* Incoming white beam */}
+          <motion.line
+            x1="0"
+            y1="20"
+            x2="15"
+            y2="18"
+            stroke="#f8fafc"
+            strokeWidth="1.6"
+            strokeLinecap="round"
+            animate={isStatic ? {} : { opacity: [0.5, 1, 0.5] }}
+            transition={{ duration: 2.4, repeat: Infinity }}
+          />
+
+          {/* Rainbow fan */}
+          {SPECTRUM.map((color, i) => (
+            <motion.line
+              key={color}
+              x1="24"
+              y1="18"
+              x2="43"
+              y2={8 + i * 4}
+              stroke={color}
+              strokeWidth="1.6"
+              strokeLinecap="round"
+              animate={isStatic ? {} : { opacity: [0.65, 1, 0.65] }}
+              transition={{
+                duration: 1.8,
+                repeat: Infinity,
+                delay: i * 0.12,
+              }}
+            />
+          ))}
+
+          {/* Prism */}
+          <path
+            d="M14 29 L24 29 L19 8 Z"
+            fill="url(#prismGlass)"
+            stroke="#c7d2fe"
+            strokeWidth="1"
+            strokeLinejoin="round"
+          />
+          {/* Glass highlight */}
+          <path
+            d="M18.2 12 L16 26"
+            stroke="#ffffff"
+            strokeWidth="0.8"
+            opacity="0.7"
+            strokeLinecap="round"
+          />
+        </svg>
+      </motion.div>
+    </motion.div>
+  );
+}

--- a/src/registry/cursors/radar.tsx
+++ b/src/registry/cursors/radar.tsx
@@ -1,0 +1,49 @@
+"use client";
+
+import { motion } from "framer-motion";
+
+export default function RadarCursor({
+  x,
+  y,
+  isStatic,
+}: {
+  x: number;
+  y: number;
+  isStatic?: boolean;
+}) {
+  return (
+    <motion.div
+      className="fixed top-0 left-0 pointer-events-none z-50"
+      style={{ x, y, translateX: "-50%", translateY: "-50%" }}
+    >
+      {/* Radar dish */}
+      <div className="relative w-10 h-10 rounded-full border border-emerald-400/70 overflow-hidden shadow-[0_0_16px_rgba(52,211,153,0.35)]">
+        {/* Grid ticks */}
+        <div className="absolute inset-0 rounded-full border border-emerald-400/20 scale-[0.66]" />
+        <div className="absolute inset-0 rounded-full border border-emerald-400/20 scale-[0.33]" />
+        {/* Sweeping beam */}
+        <motion.div
+          className="absolute inset-0 rounded-full"
+          style={{
+            background:
+              "conic-gradient(from 0deg, rgba(52,211,153,0.55), transparent 70deg)",
+          }}
+          animate={isStatic ? {} : { rotate: 360 }}
+          transition={{ duration: 2.2, repeat: Infinity, ease: "linear" }}
+        />
+      </div>
+
+      {/* Ping ring */}
+      {!isStatic && (
+        <motion.div
+          className="absolute inset-0 rounded-full border border-emerald-400/60"
+          animate={{ scale: [1, 2.1], opacity: [0.8, 0] }}
+          transition={{ duration: 2.2, repeat: Infinity, ease: "easeOut" }}
+        />
+      )}
+
+      {/* Blip */}
+      <div className="absolute left-1/2 top-1/2 w-1.5 h-1.5 -translate-x-1/2 -translate-y-1/2 rounded-full bg-emerald-400 shadow-[0_0_8px_rgba(52,211,153,0.9)]" />
+    </motion.div>
+  );
+}

--- a/src/registry/cursors/registry.test.ts
+++ b/src/registry/cursors/registry.test.ts
@@ -1,0 +1,53 @@
+import { describe, it, expect } from "vitest";
+import fs from "fs";
+import path from "path";
+import { CURSORS } from "./index";
+
+describe("cursor registry", () => {
+  it("has a healthy number of cursors", () => {
+    expect(CURSORS.length).toBeGreaterThanOrEqual(80);
+  });
+
+  it("every cursor has a unique id", () => {
+    const ids = CURSORS.map((c) => c.id);
+    expect(new Set(ids).size).toBe(ids.length);
+  });
+
+  it("every cursor has the required metadata", () => {
+    for (const cursor of CURSORS) {
+      expect(cursor.id, "id").toBeTruthy();
+      expect(cursor.id, `id "${cursor.id}" must be kebab-case`).toMatch(
+        /^[a-z0-9]+(-[a-z0-9]+)*$/
+      );
+      expect(cursor.name, `${cursor.id} name`).toBeTruthy();
+      expect(cursor.description, `${cursor.id} description`).toBeTruthy();
+      expect(
+        cursor.tags.length,
+        `${cursor.id} should have at least one tag`
+      ).toBeGreaterThan(0);
+      expect(cursor.component, `${cursor.id} component`).toBeDefined();
+      expect(cursor.code.react, `${cursor.id} react code`).toBeDefined();
+      expect(cursor.code.vanilla, `${cursor.id} vanilla code`).toBeDefined();
+    }
+  });
+
+  it("every cursor id maps to a source file (used by the API routes)", () => {
+    for (const cursor of CURSORS) {
+      const filePath = path.join(__dirname, `${cursor.id}.tsx`);
+      expect(
+        fs.existsSync(filePath),
+        `missing source file for "${cursor.id}" — expected src/registry/cursors/${cursor.id}.tsx`
+      ).toBe(true);
+    }
+  });
+
+  it("featured cursors are a curated subset", () => {
+    const featured = CURSORS.filter((c) => c.featured);
+    expect(featured.length).toBeGreaterThan(0);
+    expect(featured.length).toBeLessThan(CURSORS.length);
+  });
+
+  it("the default cursor exists and is first", () => {
+    expect(CURSORS[0].id).toBe("default");
+  });
+});

--- a/src/registry/cursors/ribbon.tsx
+++ b/src/registry/cursors/ribbon.tsx
@@ -1,0 +1,76 @@
+"use client";
+
+import { motion } from "framer-motion";
+import { useEffect, useRef, useState } from "react";
+
+interface Point {
+  x: number;
+  y: number;
+  id: number;
+}
+
+const TRAIL = 12;
+
+export default function RibbonCursor({
+  x,
+  y,
+  isStatic,
+}: {
+  x: number;
+  y: number;
+  isStatic?: boolean;
+}) {
+  const [points, setPoints] = useState<Point[]>([]);
+  const idRef = useRef(0);
+
+  useEffect(() => {
+    if (isStatic) return;
+    setPoints((prev) => [
+      ...prev.slice(-(TRAIL - 1)),
+      { x, y, id: idRef.current++ },
+    ]);
+  }, [x, y, isStatic]);
+
+  const path =
+    points.length > 1
+      ? points.map((p, i) => `${i === 0 ? "M" : "L"}${p.x} ${p.y}`).join(" ")
+      : "";
+
+  return (
+    <>
+      {/* Flowing silk ribbon */}
+      {path && (
+        <svg className="fixed top-0 left-0 w-full h-full pointer-events-none z-40 overflow-visible">
+          <defs>
+            <linearGradient id="ribbonGrad" x1="0%" y1="0%" x2="100%" y2="0%">
+              <stop offset="0%" stopColor="#22d3ee" stopOpacity="0" />
+              <stop offset="55%" stopColor="#818cf8" stopOpacity="0.75" />
+              <stop offset="100%" stopColor="#c084fc" />
+            </linearGradient>
+          </defs>
+          <path
+            d={path}
+            fill="none"
+            stroke="url(#ribbonGrad)"
+            strokeWidth="3.5"
+            strokeLinecap="round"
+            strokeLinejoin="round"
+          />
+        </svg>
+      )}
+
+      {/* Leading jewel */}
+      <motion.div
+        className="fixed top-0 left-0 w-3 h-3 rounded-full pointer-events-none z-50"
+        style={{
+          x,
+          y,
+          translateX: "-50%",
+          translateY: "-50%",
+          background: "linear-gradient(135deg, #c084fc, #818cf8)",
+          boxShadow: "0 0 12px rgba(168,85,247,0.7)",
+        }}
+      />
+    </>
+  );
+}

--- a/src/registry/cursors/robot.tsx
+++ b/src/registry/cursors/robot.tsx
@@ -1,57 +1,122 @@
 "use client";
+
 import { motion } from "framer-motion";
 
-export default function RobotCursor({ x, y }: { x: number; y: number }) {
+export default function RobotCursor({
+  x,
+  y,
+  isHovering,
+  isStatic,
+}: {
+  x: number;
+  y: number;
+  isHovering?: boolean;
+  isStatic?: boolean;
+}) {
   return (
     <motion.div
-      className="fixed top-0 left-0 pointer-events-none z-50 flex items-center justify-center"
+      className="fixed top-0 left-0 pointer-events-none z-50"
       style={{ x, y, translateX: "-50%", translateY: "-50%" }}
     >
-      <div className="relative overflow-hidden rounded-lg p-1">
-        <svg
-          width="32"
-          height="32"
-          viewBox="0 0 24 24"
-          fill="none"
-          xmlns="http://www.w3.org/2000/svg"
-        >
+      <motion.div
+        className="relative overflow-hidden rounded-lg"
+        animate={{
+          rotate: isHovering ? -6 : 0,
+          scale: isHovering ? 1.08 : 1,
+        }}
+        transition={{ type: "spring", stiffness: 300, damping: 18 }}
+        style={{ filter: "drop-shadow(0 0 8px rgba(34,211,238,0.35))" }}
+      >
+        <svg width="34" height="34" viewBox="0 0 24 24">
+          <defs>
+            <linearGradient id="robotMetal" x1="0%" y1="0%" x2="0%" y2="100%">
+              <stop offset="0%" stopColor="#e2e8f0" />
+              <stop offset="55%" stopColor="#94a3b8" />
+              <stop offset="100%" stopColor="#64748b" />
+            </linearGradient>
+          </defs>
+
+          {/* Antenna */}
+          <path
+            d="M12 8V4"
+            stroke="#64748b"
+            strokeWidth="1.6"
+            strokeLinecap="round"
+          />
+          <motion.circle
+            cx="12"
+            cy="3"
+            r="1.3"
+            fill="#22d3ee"
+            style={{ filter: "drop-shadow(0 0 3px #22d3ee)" }}
+            animate={isStatic ? {} : { opacity: [1, 0.3, 1] }}
+            transition={{ duration: 1.6, repeat: Infinity }}
+          />
+
+          {/* Head */}
           <rect
             x="3"
-            y="11"
+            y="8"
             width="18"
-            height="10"
+            height="13"
+            rx="3"
+            fill="url(#robotMetal)"
+            stroke="#475569"
+            strokeWidth="0.75"
+          />
+          {/* Face plate */}
+          <rect
+            x="5.5"
+            y="10.5"
+            width="13"
+            height="6.5"
             rx="2"
-            stroke="currentColor"
-            strokeWidth="2"
+            fill="#0f172a"
           />
+
+          {/* Eyes */}
+          <motion.circle
+            cx="9"
+            cy="13.8"
+            r="1.5"
+            fill="#22d3ee"
+            style={{ filter: "drop-shadow(0 0 3px #22d3ee)" }}
+            animate={isStatic ? {} : { opacity: [1, 0.4, 1] }}
+            transition={{ duration: 2, repeat: Infinity }}
+          />
+          <motion.circle
+            cx="15"
+            cy="13.8"
+            r="1.5"
+            fill="#22d3ee"
+            style={{ filter: "drop-shadow(0 0 3px #22d3ee)" }}
+            animate={isStatic ? {} : { opacity: [0.4, 1, 0.4] }}
+            transition={{ duration: 2, repeat: Infinity }}
+          />
+
+          {/* Mouth grille */}
           <path
-            d="M12 11V7M12 7V3M12 7H16M12 7H8"
-            stroke="currentColor"
-            strokeWidth="2"
+            d="M8.5 18.8 H15.5"
+            stroke="#475569"
+            strokeWidth="1"
+            strokeLinecap="round"
+            strokeDasharray="1.6 1.4"
           />
-          <circle cx="8" cy="16" r="1.5" fill="currentColor">
-            <animate
-              attributeName="opacity"
-              values="0.3;1;0.3"
-              dur="2s"
-              repeatCount="indefinite"
-            />
-          </circle>
-          <circle cx="16" cy="16" r="1.5" fill="currentColor">
-            <animate
-              attributeName="opacity"
-              values="1;0.3;1"
-              dur="2s"
-              repeatCount="indefinite"
-            />
-          </circle>
+
+          {/* Ear bolts */}
+          <circle cx="3" cy="14.5" r="1.1" fill="#94a3b8" />
+          <circle cx="21" cy="14.5" r="1.1" fill="#94a3b8" />
         </svg>
-        <motion.div
-          className="absolute top-0 left-0 w-full h-[1px] bg-cyan-400 shadow-[0_0_8px_cyan]"
-          animate={{ top: ["20%", "80%", "20%"] }}
-          transition={{ duration: 3, repeat: Infinity, ease: "linear" }}
-        />
-      </div>
+
+        {/* Scan line */}
+        {!isStatic && (
+          <motion.div
+            className="absolute left-0 w-full h-[1px] bg-cyan-400/70 shadow-[0_0_6px_cyan]"
+            animate={{ top: ["22%", "82%", "22%"] }}
+            transition={{ duration: 3, repeat: Infinity, ease: "linear" }}
+          />
+        )}
+      </motion.div>
     </motion.div>
   );
 }

--- a/src/registry/cursors/saber.tsx
+++ b/src/registry/cursors/saber.tsx
@@ -1,0 +1,69 @@
+"use client";
+
+import { motion } from "framer-motion";
+import { useEffect, useRef, useState } from "react";
+
+export default function SaberCursor({
+  x,
+  y,
+  isHovering,
+  isStatic,
+}: {
+  x: number;
+  y: number;
+  isHovering?: boolean;
+  isStatic?: boolean;
+}) {
+  const [angle, setAngle] = useState(-45);
+  const prevRef = useRef({ x, y });
+
+  useEffect(() => {
+    const dx = x - prevRef.current.x;
+    const dy = y - prevRef.current.y;
+    prevRef.current = { x, y };
+    if (Math.hypot(dx, dy) > 0.5) {
+      setAngle((Math.atan2(dy, dx) * 180) / Math.PI);
+    }
+  }, [x, y]);
+
+  return (
+    <motion.div
+      className="fixed top-0 left-0 pointer-events-none z-50"
+      style={{ x, y }}
+    >
+      {/* Blade assembly — hilt sits on the cursor point, blade extends out */}
+      <motion.div
+        className="absolute left-0 top-0 flex items-center"
+        animate={{ rotate: angle }}
+        transition={{ type: "spring", stiffness: 230, damping: 21 }}
+        style={{ transformOrigin: "4px 0px", translateY: "-50%" }}
+      >
+        {/* Hilt */}
+        <div className="relative w-[10px] h-[7px] rounded-[2px] bg-gradient-to-b from-zinc-300 via-zinc-500 to-zinc-700 shadow-md">
+          <div className="absolute left-[2px] top-0 w-[1px] h-full bg-zinc-800/60" />
+          <div className="absolute left-[5px] top-0 w-[1px] h-full bg-zinc-800/60" />
+          <div className="absolute right-[1.5px] top-[2px] w-[2px] h-[3px] rounded-[1px] bg-red-500/80" />
+        </div>
+
+        {/* Blade */}
+        <motion.div
+          className="relative h-[6px] w-[46px] rounded-full"
+          animate={
+            isStatic ? {} : { opacity: [0.92, 1, 0.9, 1], scaleY: [1, 1.12, 1] }
+          }
+          transition={{ duration: 1.4, repeat: Infinity }}
+          style={{
+            background:
+              "linear-gradient(to right, rgba(103,232,249,0.9), rgba(103,232,249,0.55) 70%, transparent)",
+            boxShadow: isHovering
+              ? "0 0 14px rgba(34,211,238,1), 0 0 34px rgba(34,211,238,0.6)"
+              : "0 0 10px rgba(34,211,238,0.85), 0 0 24px rgba(34,211,238,0.45)",
+          }}
+        >
+          {/* White-hot core */}
+          <div className="absolute inset-y-[1.5px] left-0 right-[6px] rounded-full bg-white/95" />
+        </motion.div>
+      </motion.div>
+    </motion.div>
+  );
+}

--- a/src/registry/cursors/sakura.tsx
+++ b/src/registry/cursors/sakura.tsx
@@ -1,0 +1,102 @@
+"use client";
+
+import { motion } from "framer-motion";
+import { useEffect, useRef, useState } from "react";
+
+interface Petal {
+  id: number;
+  x: number;
+  y: number;
+  size: number;
+  drift: number;
+  rotate: number;
+}
+
+export default function SakuraCursor({
+  x,
+  y,
+  isStatic,
+}: {
+  x: number;
+  y: number;
+  isStatic?: boolean;
+}) {
+  const [petals, setPetals] = useState<Petal[]>([]);
+  const idRef = useRef(0);
+
+  useEffect(() => {
+    if (isStatic) return;
+    const interval = setInterval(() => {
+      setPetals((prev) => [
+        ...prev.slice(-6),
+        {
+          id: idRef.current++,
+          x: x + (Math.random() - 0.5) * 36,
+          y: y - 10,
+          size: Math.random() * 4 + 4,
+          drift: (Math.random() - 0.5) * 30,
+          rotate: Math.random() * 180 - 90,
+        },
+      ]);
+    }, 150);
+    return () => clearInterval(interval);
+  }, [x, y, isStatic]);
+
+  return (
+    <>
+      {/* Drifting petals */}
+      {petals.map((p) => (
+        <motion.div
+          key={p.id}
+          className="fixed top-0 left-0 pointer-events-none z-40"
+          style={{
+            x: p.x,
+            y: p.y,
+            width: p.size,
+            height: p.size * 0.8,
+            borderRadius: "80% 20% 80% 20%",
+            background: "linear-gradient(135deg, #fbcfe8, #f9a8d4)",
+            boxShadow: "0 0 4px rgba(249,168,212,0.5)",
+          }}
+          initial={{ opacity: 0.95, rotate: p.rotate }}
+          animate={{
+            opacity: 0,
+            y: p.y + 44,
+            x: p.x + p.drift,
+            rotate: p.rotate + 160,
+          }}
+          transition={{ duration: 1.4, ease: "easeIn" }}
+        />
+      ))}
+
+      {/* Heart of the blossom */}
+      <motion.div
+        className="fixed top-0 left-0 pointer-events-none z-50"
+        style={{ x, y, translateX: "-50%", translateY: "-50%" }}
+      >
+        <svg
+          width="20"
+          height="20"
+          viewBox="0 0 24 24"
+          style={{ filter: "drop-shadow(0 0 6px rgba(244,114,182,0.6))" }}
+        >
+          {/* Five simple blossom petals */}
+          {[0, 72, 144, 216, 288].map((deg) => (
+            <ellipse
+              key={deg}
+              cx="12"
+              cy="6.6"
+              rx="2.6"
+              ry="4.2"
+              fill="#f9a8d4"
+              stroke="#f472b6"
+              strokeWidth="0.5"
+              transform={`rotate(${deg} 12 12)`}
+            />
+          ))}
+          <circle cx="12" cy="12" r="2.1" fill="#fde047" />
+        </svg>
+      </motion.div>
+    </>
+  );
+}

--- a/src/registry/cursors/skull.tsx
+++ b/src/registry/cursors/skull.tsx
@@ -1,57 +1,184 @@
 "use client";
+
 import { motion } from "framer-motion";
+import { useEffect, useRef, useState } from "react";
 
-export default function SkullCursor({ x, y }: { x: number; y: number }) {
+interface Ember {
+  id: number;
+  x: number;
+  y: number;
+  size: number;
+  drift: number;
+}
+
+export default function SkullCursor({
+  x,
+  y,
+  isHovering,
+  isStatic,
+}: {
+  x: number;
+  y: number;
+  isHovering?: boolean;
+  isStatic?: boolean;
+}) {
+  const [embers, setEmbers] = useState<Ember[]>([]);
+  const idRef = useRef(0);
+
+  useEffect(() => {
+    if (isStatic) return;
+    const interval = setInterval(() => {
+      setEmbers((prev) => [
+        ...prev.slice(-4),
+        {
+          id: idRef.current++,
+          x: x + (Math.random() - 0.5) * 14,
+          y: y - 6,
+          size: Math.random() * 2.5 + 1.5,
+          drift: (Math.random() - 0.5) * 10,
+        },
+      ]);
+    }, 160);
+    return () => clearInterval(interval);
+  }, [x, y, isStatic]);
+
   return (
-    <motion.div
-      className="fixed top-0 left-0 pointer-events-none z-50 flex items-center justify-center"
-      style={{ x, y, translateX: "-50%", translateY: "-50%" }}
-    >
-      <div className="relative">
-        <svg
-          width="32"
-          height="32"
-          viewBox="0 0 24 24"
-          fill="none"
-          xmlns="http://www.w3.org/2000/svg"
+    <>
+      {/* Rising embers */}
+      {embers.map((e) => (
+        <motion.div
+          key={e.id}
+          className="fixed top-0 left-0 rounded-full pointer-events-none z-40 bg-orange-400"
+          style={{
+            x: e.x,
+            y: e.y,
+            translateX: "-50%",
+            translateY: "-50%",
+            width: e.size,
+            height: e.size,
+            boxShadow: "0 0 6px rgba(251,146,60,0.9)",
+          }}
+          initial={{ opacity: 0.9 }}
+          animate={{ opacity: 0, y: e.y - 34, x: e.x + e.drift }}
+          transition={{ duration: 0.9, ease: "easeOut" }}
+        />
+      ))}
+
+      <motion.div
+        className="fixed top-0 left-0 pointer-events-none z-50"
+        style={{ x, y, translateX: "-50%", translateY: "-50%" }}
+      >
+        <motion.div
+          animate={{ scale: isHovering ? 1.08 : 1 }}
+          transition={{ type: "spring", stiffness: 350, damping: 18 }}
         >
-          <path
-            d="M12 2C7.02944 2 3 6.02944 3 11C3 13.5 4 15.6 5.6 17H5.5C5.22386 17 5 17.2239 5 17.5V20.5C5 20.7761 5.22386 21 5.5 21H18.5C18.7761 21 19 20.7761 19 20.5V17.5C19 17.2239 18.7761 17 18.5 17H18.4C20 15.6 21 13.5 21 11C21 6.02944 16.9706 2 12 2Z"
-            fill="#e2e8f0"
-            stroke="#94a3b8"
-            strokeWidth="1.5"
-          />
-          <path
-            d="M8 18V21M12 18V21M16 18V21"
-            stroke="#94a3b8"
-            strokeWidth="1.5"
-            strokeLinecap="round"
-          />
+          <svg
+            width="34"
+            height="34"
+            viewBox="0 0 32 32"
+            style={{
+              filter: "drop-shadow(0 0 10px rgba(15,23,42,0.55))",
+            }}
+          >
+            <defs>
+              <linearGradient id="skullBone" x1="0%" y1="0%" x2="0%" y2="100%">
+                <stop offset="0%" stopColor="#f1f5f9" />
+                <stop offset="60%" stopColor="#cbd5e1" />
+                <stop offset="100%" stopColor="#94a3b8" />
+              </linearGradient>
+            </defs>
 
-          {/* Eyes with glow */}
-          <circle cx="8" cy="11" r="3" fill="#1e293b" />
-          <circle cx="16" cy="11" r="3" fill="#1e293b" />
-          <motion.circle
-            cx="8"
-            cy="11"
-            r="1.5"
-            fill="#ef4444"
-            animate={{ opacity: [1, 0.4, 1] }}
-            transition={{ duration: 2, repeat: Infinity }}
-          />
-          <motion.circle
-            cx="16"
-            cy="11"
-            r="1.5"
-            fill="#ef4444"
-            animate={{ opacity: [1, 0.4, 1] }}
-            transition={{ duration: 2, repeat: Infinity }}
-          />
+            {/* Cranium + jaw */}
+            <path
+              d="M16 3.5 C10.2 3.5 5.8 7.9 5.8 13.4 C5.8 16.4 6.9 18.9 8.7 20.5 L9.2 24.8 C9.3 26 10.3 27 11.5 27 L20.5 27 C21.7 27 22.7 26 22.8 24.8 L23.3 20.5 C25.1 18.9 26.2 16.4 26.2 13.4 C26.2 7.9 21.8 3.5 16 3.5 Z"
+              fill="url(#skullBone)"
+              stroke="#64748b"
+              strokeWidth="0.75"
+              strokeLinejoin="round"
+            />
 
-          {/* Nose */}
-          <path d="M12 14L11 15H13L12 14Z" fill="#1e293b" />
-        </svg>
-      </div>
-    </motion.div>
+            {/* Cracks */}
+            <path
+              d="M13 5.5 L14.2 8.2 L13.4 9.8"
+              stroke="#94a3b8"
+              strokeWidth="0.6"
+              strokeLinecap="round"
+              fill="none"
+            />
+            <path
+              d="M20.5 6 L19.8 8.4"
+              stroke="#94a3b8"
+              strokeWidth="0.6"
+              strokeLinecap="round"
+              fill="none"
+            />
+
+            {/* Eye sockets */}
+            <ellipse cx="11.8" cy="14.2" rx="2.9" ry="3.2" fill="#0f172a" />
+            <ellipse cx="20.2" cy="14.2" rx="2.9" ry="3.2" fill="#0f172a" />
+
+            {/* Ember gaze */}
+            <motion.circle
+              cx="11.8"
+              cy="14.6"
+              r="1.25"
+              fill="#fb923c"
+              style={{ filter: "drop-shadow(0 0 3px #f97316)" }}
+              animate={
+                isStatic
+                  ? {}
+                  : {
+                      opacity: [1, 0.35, 1],
+                      r: isHovering ? [1.25, 1.7, 1.25] : [1.25, 1, 1.25],
+                    }
+              }
+              transition={{
+                duration: 2.2,
+                repeat: Infinity,
+                ease: "easeInOut",
+              }}
+            />
+            <motion.circle
+              cx="20.2"
+              cy="14.6"
+              r="1.25"
+              fill="#fb923c"
+              style={{ filter: "drop-shadow(0 0 3px #f97316)" }}
+              animate={
+                isStatic
+                  ? {}
+                  : {
+                      opacity: [1, 0.35, 1],
+                      r: isHovering ? [1.25, 1.7, 1.25] : [1.25, 1, 1.25],
+                    }
+              }
+              transition={{
+                duration: 2.2,
+                repeat: Infinity,
+                ease: "easeInOut",
+                delay: 0.15,
+              }}
+            />
+
+            {/* Nose cavity */}
+            <path d="M16 17.8 L14.8 20.4 L17.2 20.4 Z" fill="#0f172a" />
+
+            {/* Jaw line + teeth */}
+            <path
+              d="M9.6 21.6 L22.4 21.6"
+              stroke="#64748b"
+              strokeWidth="0.6"
+              opacity="0.6"
+            />
+            <path
+              d="M12.4 21.6 L12.4 26.3 M16 21.6 L16 26.7 M19.6 21.6 L19.6 26.3"
+              stroke="#64748b"
+              strokeWidth="0.8"
+              strokeLinecap="round"
+            />
+          </svg>
+        </motion.div>
+      </motion.div>
+    </>
   );
 }

--- a/src/registry/cursors/spotlight.tsx
+++ b/src/registry/cursors/spotlight.tsx
@@ -1,0 +1,56 @@
+"use client";
+
+import { motion, useMotionValue, useSpring } from "framer-motion";
+import { useEffect } from "react";
+
+export default function SpotlightCursor({
+  x,
+  y,
+  isHovering,
+}: {
+  x: number;
+  y: number;
+  isHovering?: boolean;
+}) {
+  const mx = useMotionValue(x);
+  const my = useMotionValue(y);
+
+  useEffect(() => {
+    mx.set(x);
+    my.set(y);
+  }, [x, y, mx, my]);
+
+  // The light pool drifts after the cursor like a real flashlight
+  const glowX = useSpring(mx, { stiffness: 110, damping: 18, mass: 0.9 });
+  const glowY = useSpring(my, { stiffness: 110, damping: 18, mass: 0.9 });
+
+  return (
+    <>
+      {/* Light pool */}
+      <motion.div
+        className="fixed top-0 left-0 w-[340px] h-[340px] rounded-full pointer-events-none z-40 bg-[radial-gradient(circle,rgba(0,0,0,0.07)_0%,transparent_70%)] dark:bg-[radial-gradient(circle,rgba(255,255,255,0.13)_0%,rgba(255,255,255,0.04)_40%,transparent_70%)]"
+        style={{
+          x: glowX,
+          y: glowY,
+          translateX: "-50%",
+          translateY: "-50%",
+        }}
+      />
+      {/* Focus ring */}
+      <motion.div
+        className="fixed top-0 left-0 w-8 h-8 rounded-full border border-zinc-400/80 dark:border-white/80 pointer-events-none z-50"
+        style={{ x, y, translateX: "-50%", translateY: "-50%" }}
+        animate={{
+          scale: isHovering ? 1.45 : 1,
+          opacity: isHovering ? 1 : 0.75,
+        }}
+        transition={{ type: "spring", stiffness: 380, damping: 22 }}
+      />
+      {/* Center pip */}
+      <motion.div
+        className="fixed top-0 left-0 w-1 h-1 rounded-full bg-zinc-600 dark:bg-white pointer-events-none z-50"
+        style={{ x, y, translateX: "-50%", translateY: "-50%" }}
+      />
+    </>
+  );
+}

--- a/src/registry/cursors/terminal.tsx
+++ b/src/registry/cursors/terminal.tsx
@@ -1,0 +1,61 @@
+"use client";
+
+import { motion } from "framer-motion";
+
+export default function TerminalCursor({
+  x,
+  y,
+  isHovering,
+}: {
+  x: number;
+  y: number;
+  isHovering?: boolean;
+}) {
+  return (
+    <motion.div
+      className="fixed top-0 left-0 pointer-events-none z-50 flex items-center"
+      style={{ x, y, translateX: "-50%", translateY: "-50%" }}
+    >
+      {/* Prompt chevron */}
+      <svg
+        width="12"
+        height="16"
+        viewBox="0 0 12 16"
+        className="mr-[3px]"
+        style={{ filter: "drop-shadow(0 0 4px rgba(52,211,153,0.6))" }}
+      >
+        <path
+          d="M2 2 L9 8 L2 14"
+          fill="none"
+          stroke="#34d399"
+          strokeWidth="2.4"
+          strokeLinecap="round"
+          strokeLinejoin="round"
+        />
+      </svg>
+
+      {/* Blinking block caret */}
+      <motion.div
+        className="w-[11px] h-[20px] rounded-[2px] bg-emerald-400"
+        style={{
+          boxShadow:
+            "0 0 12px rgba(52,211,153,0.8), 0 0 32px rgba(52,211,153,0.35)",
+          transformOrigin: "bottom center",
+        }}
+        animate={{
+          opacity: [1, 1, 0, 0],
+          scaleY: isHovering ? 0.25 : 1,
+        }}
+        transition={{
+          opacity: {
+            duration: 1.06,
+            repeat: Infinity,
+            times: [0, 0.5, 0.5, 1],
+            ease: "linear",
+          },
+          scaleY: { type: "spring", stiffness: 500, damping: 26 },
+        }}
+      />
+    </motion.div>
+  );
+}

--- a/src/registry/cursors/ufo.tsx
+++ b/src/registry/cursors/ufo.tsx
@@ -1,0 +1,90 @@
+"use client";
+
+import { motion } from "framer-motion";
+
+export default function UfoCursor({
+  x,
+  y,
+  isStatic,
+}: {
+  x: number;
+  y: number;
+  isStatic?: boolean;
+}) {
+  return (
+    <motion.div
+      className="fixed top-0 left-0 pointer-events-none z-50"
+      style={{ x, y, translateX: "-50%", translateY: "-50%" }}
+    >
+      <motion.div
+        animate={isStatic ? {} : { y: [0, -4, 0], rotate: [0, -3, 3, 0] }}
+        transition={{ duration: 2.4, repeat: Infinity, ease: "easeInOut" }}
+      >
+        <svg width="38" height="30" viewBox="0 0 38 30">
+          {/* Tractor beam */}
+          <motion.path
+            d="M13 17 L25 17 L31 29 L7 29 Z"
+            fill="url(#ufoBeamGrad)"
+            animate={isStatic ? {} : { opacity: [0.15, 0.45, 0.15] }}
+            transition={{ duration: 1.8, repeat: Infinity, ease: "easeInOut" }}
+          />
+          {/* Glass dome */}
+          <path
+            d="M13 12 C13 5 25 5 25 12 Z"
+            fill="url(#ufoDomeGrad)"
+            opacity="0.95"
+          />
+          {/* Saucer body */}
+          <ellipse
+            cx="19"
+            cy="13.5"
+            rx="16"
+            ry="5.5"
+            fill="url(#ufoBodyGrad)"
+          />
+          <ellipse
+            cx="19"
+            cy="12.6"
+            rx="16"
+            ry="5.5"
+            fill="none"
+            stroke="rgba(255,255,255,0.35)"
+            strokeWidth="0.6"
+          />
+          {/* Running lights */}
+          {[8, 19, 30].map((cx, i) => (
+            <motion.circle
+              key={cx}
+              cx={cx}
+              cy="15.5"
+              r="1.6"
+              fill="#fbbf24"
+              animate={isStatic ? {} : { opacity: [0.2, 1, 0.2] }}
+              transition={{
+                duration: 1.2,
+                repeat: Infinity,
+                delay: i * 0.4,
+                ease: "easeInOut",
+              }}
+            />
+          ))}
+          <defs>
+            <linearGradient id="ufoBodyGrad" x1="0%" y1="0%" x2="0%" y2="100%">
+              <stop offset="0%" stopColor="#e2e8f0" />
+              <stop offset="55%" stopColor="#94a3b8" />
+              <stop offset="100%" stopColor="#475569" />
+            </linearGradient>
+            <linearGradient id="ufoDomeGrad" x1="0%" y1="0%" x2="0%" y2="100%">
+              <stop offset="0%" stopColor="#a5f3fc" />
+              <stop offset="100%" stopColor="#0891b2" />
+            </linearGradient>
+            <linearGradient id="ufoBeamGrad" x1="0%" y1="0%" x2="0%" y2="100%">
+              <stop offset="0%" stopColor="rgba(190,242,100,0.55)" />
+              <stop offset="100%" stopColor="rgba(190,242,100,0)" />
+            </linearGradient>
+          </defs>
+        </svg>
+      </motion.div>
+    </motion.div>
+  );
+}

--- a/src/registry/cursors/vinyl.tsx
+++ b/src/registry/cursors/vinyl.tsx
@@ -1,0 +1,98 @@
+"use client";
+
+import { motion } from "framer-motion";
+
+export default function VinylCursor({
+  x,
+  y,
+  isHovering,
+  isStatic,
+}: {
+  x: number;
+  y: number;
+  isHovering?: boolean;
+  isStatic?: boolean;
+}) {
+  return (
+    <motion.div
+      className="fixed top-0 left-0 pointer-events-none z-50"
+      style={{ x, y, translateX: "-50%", translateY: "-50%" }}
+    >
+      <motion.div
+        animate={{
+          rotate: isStatic ? 0 : 360,
+          scale: isHovering ? 1.12 : 1,
+        }}
+        transition={{
+          rotate: { duration: 2.4, repeat: Infinity, ease: "linear" },
+          scale: { type: "spring", stiffness: 320, damping: 18 },
+        }}
+        style={{ filter: "drop-shadow(0 0 8px rgba(0,0,0,0.5))" }}
+      >
+        <svg width="34" height="34" viewBox="0 0 34 34">
+          <defs>
+            <radialGradient id="vinylDisc" cx="42%" cy="38%" r="70%">
+              <stop offset="0%" stopColor="#3f3f46" />
+              <stop offset="70%" stopColor="#18181b" />
+              <stop offset="100%" stopColor="#09090b" />
+            </radialGradient>
+            <linearGradient id="vinylLabel" x1="0%" y1="0%" x2="100%" y2="100%">
+              <stop offset="0%" stopColor="#fb923c" />
+              <stop offset="100%" stopColor="#ea580c" />
+            </linearGradient>
+          </defs>
+
+          {/* Disc */}
+          <circle
+            cx="17"
+            cy="17"
+            r="16"
+            fill="url(#vinylDisc)"
+            stroke="#27272a"
+            strokeWidth="0.75"
+          />
+          {/* Grooves */}
+          <circle
+            cx="17"
+            cy="17"
+            r="13"
+            fill="none"
+            stroke="#3f3f46"
+            strokeWidth="0.4"
+            opacity="0.8"
+          />
+          <circle
+            cx="17"
+            cy="17"
+            r="10.5"
+            fill="none"
+            stroke="#3f3f46"
+            strokeWidth="0.4"
+            opacity="0.7"
+          />
+          <circle
+            cx="17"
+            cy="17"
+            r="8"
+            fill="none"
+            stroke="#3f3f46"
+            strokeWidth="0.4"
+            opacity="0.6"
+          />
+          {/* Shine */}
+          <path
+            d="M6 10 A13 13 0 0 1 14 4.5"
+            stroke="#fafafa"
+            strokeWidth="1.1"
+            strokeLinecap="round"
+            opacity="0.35"
+            fill="none"
+          />
+          {/* Label */}
+          <circle cx="17" cy="17" r="5" fill="url(#vinylLabel)" />
+          <circle cx="17" cy="17" r="1.1" fill="#fafafa" />
+        </svg>
+      </motion.div>
+    </motion.div>
+  );
+}

--- a/src/registry/cursors/vortex.tsx
+++ b/src/registry/cursors/vortex.tsx
@@ -1,0 +1,38 @@
+"use client";
+
+import { motion } from "framer-motion";
+
+export default function VortexCursor({
+  x,
+  y,
+  isStatic,
+}: {
+  x: number;
+  y: number;
+  isStatic?: boolean;
+}) {
+  return (
+    <motion.div
+      className="fixed top-0 left-0 pointer-events-none z-50"
+      style={{ x, y, translateX: "-50%", translateY: "-50%" }}
+    >
+      {/* Spinning swirl */}
+      <motion.div
+        className="w-9 h-9 rounded-full"
+        style={{
+          background:
+            "conic-gradient(from 0deg, transparent 0deg, rgba(168,85,247,0.85) 90deg, transparent 180deg, rgba(59,130,246,0.85) 270deg, transparent 360deg)",
+          filter: "blur(1px)",
+          maskImage:
+            "radial-gradient(circle, transparent 28%, black 45%, black 78%, transparent 100%)",
+          WebkitMaskImage:
+            "radial-gradient(circle, transparent 28%, black 45%, black 78%, transparent 100%)",
+        }}
+        animate={isStatic ? {} : { rotate: -360 }}
+        transition={{ duration: 1.8, repeat: Infinity, ease: "linear" }}
+      />
+      {/* Event horizon */}
+      <div className="absolute left-1/2 top-1/2 w-2.5 h-2.5 -translate-x-1/2 -translate-y-1/2 rounded-full bg-white shadow-[0_0_14px_rgba(168,85,247,0.9),0_0_30px_rgba(59,130,246,0.5)]" />
+    </motion.div>
+  );
+}

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,0 +1,14 @@
+import { defineConfig } from "vitest/config";
+import path from "path";
+
+export default defineConfig({
+  resolve: {
+    alias: {
+      "@": path.resolve(__dirname, "./src"),
+    },
+  },
+  test: {
+    environment: "node",
+    include: ["src/**/*.test.ts"],
+  },
+});


### PR DESCRIPTION
## Summary

**101 cursors total** (73 → 101), with the flat emoji-style ones rebuilt as layered SVG art, plus a noticeable smoothness boost when sweeping across the gallery.

### Performance
- Split cursor context into state/actions contexts — hovering between cards no longer re-renders every visible card
- Rewrote the engine's mouse loop (single guaranteed rAF per frame, no cancel/starvation on high-polling mice, no 2px dead-zone)
- Card previews render static only — the single live instance follows the mouse

### New cursors (28)
Aurora, Halo, Comet, Spotlight, Chromatic, Goo, Fireflies, Radar, Aperture, Vortex, Constellation, Paper Plane, UFO, Butterfly, Laser, Terminal, Matrix, Prism, Galaxy, Saber, Ink, Vinyl, Sakura, Lantern, Eclipse, Potion, Ribbon, Plasma

### Redesigned / improved
- **Rebuilt:** skull (ember gaze), key (ornate skeleton key), flame (3-layer living fire)
- **Improved:** coffee (to-go cup), terminal (chevron prompt + caret)
- **Polished:** crown, lock, pizza, robot (gradients, glows, hover states)

### SEO
- `sitemap.ts` + `robots.ts`, JSON-LD (WebSite + SoftwareApplication)
- Fixed title typo, added title template, canonical URLs, robots/googleBot directives, 21 keywords
- Dynamic cursor counts in copy/metadata (never stale again)

### Other
- 'Meet the Maker' section on the sponsor page
- New gallery filter categories (Animated, Creative)
- Vitest registry integrity tests (`npm test`)

### Verification
- `tsc` clean, ESLint clean, Prettier clean, 6/6 tests pass, production build succeeds