### PR TITLE
feat: cloud/moon/globe redesigns, 3 new cursors (104 total), hero drop pill

### DIFF
--- a/src/components/layout/hero.tsx
+++ b/src/components/layout/hero.tsx
@@ -2,8 +2,9 @@
 
 import { Button } from "@/components/ui/button";
 import { motion } from "framer-motion";
-import { ArrowRight, Github } from "lucide-react";
+import { ArrowRight, Github, Sparkles } from "lucide-react";
 import Link from "next/link";
+import { CURSORS } from "@/registry/cursors";
 
 export function Hero() {
   return (
@@ -25,6 +26,32 @@ export function Hero() {
                 Fully Compatible with Shadcn CLI
               </span>
             </div>
+
+            {/* Fresh drop pill */}
+            <Link href="/cursors" className="group">
+              <motion.div
+                initial={{ opacity: 0, scale: 0.9 }}
+                animate={{ opacity: 1, scale: 1 }}
+                transition={{ duration: 0.5, delay: 0.35 }}
+                className="relative inline-flex items-center gap-2.5 overflow-hidden rounded-full border border-border/70 bg-muted/40 px-4 py-1.5 transition-colors group-hover:border-primary/40 group-hover:bg-primary/5"
+              >
+                <motion.div
+                  className="absolute inset-0 bg-gradient-to-r from-transparent via-primary/15 to-transparent"
+                  animate={{ x: ["-100%", "200%"] }}
+                  transition={{
+                    duration: 2.6,
+                    repeat: Infinity,
+                    ease: "easeInOut",
+                    repeatDelay: 1.4,
+                  }}
+                />
+                <Sparkles className="relative w-3 h-3 text-primary" />
+                <span className="relative text-[10px] font-black uppercase tracking-[0.2em] text-muted-foreground transition-colors group-hover:text-foreground">
+                  31 New Cursors Just Dropped
+                </span>
+                <ArrowRight className="relative w-3 h-3 text-primary transition-transform group-hover:translate-x-0.5" />
+              </motion.div>
+            </Link>
           </motion.div>
 
           {/* Main Headline */}
@@ -99,7 +126,7 @@ export function Hero() {
             className="mt-24 pt-12 border-t border-border flex flex-wrap justify-center items-center gap-12"
           >
             {[
-              { label: "CURSORS", value: "70+" },
+              { label: "CURSORS", value: `${CURSORS.length}+` },
               { label: "ENGINE", value: "MOTION" },
               { label: "LIBRARY", value: "SHADCN" },
               { label: "LICENSE", value: "MIT" },

--- a/src/registry/cursors/bokeh.tsx
+++ b/src/registry/cursors/bokeh.tsx
@@ -1,0 +1,90 @@
+"use client";
+
+import { motion, useMotionValue, useSpring } from "framer-motion";
+import type { MotionValue } from "framer-motion";
+import { useEffect } from "react";
+
+const ORBS = [
+  {
+    size: 26,
+    color: "rgba(244,114,182,0.4)",
+    stiffness: 60,
+    offsetX: -16,
+    offsetY: -12,
+  },
+  {
+    size: 20,
+    color: "rgba(103,232,249,0.45)",
+    stiffness: 90,
+    offsetX: 14,
+    offsetY: -16,
+  },
+  {
+    size: 16,
+    color: "rgba(253,224,71,0.4)",
+    stiffness: 120,
+    offsetX: 18,
+    offsetY: 12,
+  },
+  {
+    size: 22,
+    color: "rgba(167,139,250,0.4)",
+    stiffness: 75,
+    offsetX: -14,
+    offsetY: 14,
+  },
+];
+
+export default function BokehCursor({ x, y }: { x: number; y: number }) {
+  const mx = useMotionValue(x);
+  const my = useMotionValue(y);
+
+  useEffect(() => {
+    mx.set(x);
+    my.set(y);
+  }, [x, y, mx, my]);
+
+  return (
+    <>
+      {ORBS.map((orb, i) => (
+        <BokehOrb key={i} mx={mx} my={my} config={orb} />
+      ))}
+      {/* Crisp center */}
+      <motion.div
+        className="fixed top-0 left-0 w-2 h-2 rounded-full bg-foreground pointer-events-none z-50"
+        style={{ x, y, translateX: "-50%", translateY: "-50%" }}
+      />
+    </>
+  );
+}
+
+function BokehOrb({
+  mx,
+  my,
+  config,
+}: {
+  mx: MotionValue<number>;
+  my: MotionValue<number>;
+  config: (typeof ORBS)[number];
+}) {
+  const ox = useSpring(mx, { stiffness: config.stiffness, damping: 16 });
+  const oy = useSpring(my, { stiffness: config.stiffness, damping: 16 });
+
+  return (
+    <motion.div
+      className="fixed top-0 left-0 rounded-full pointer-events-none z-40"
+      style={{
+        x: ox,
+        y: oy,
+        translateX: "-50%",
+        translateY: "-50%",
+        width: config.size,
+        height: config.size,
+        marginLeft: config.offsetX,
+        marginTop: config.offsetY,
+        background: `radial-gradient(circle, ${config.color} 0%, transparent 70%)`,
+        filter: "blur(4px)",
+      }}
+    />
+  );
+}

--- a/src/registry/cursors/browser.tsx
+++ b/src/registry/cursors/browser.tsx
@@ -1,37 +1,112 @@
 "use client";
+
 import { motion } from "framer-motion";
 
-export default function BrowserCursor({ x, y }: { x: number; y: number }) {
+export default function BrowserCursor({
+  x,
+  y,
+  isHovering,
+  isStatic,
+}: {
+  x: number;
+  y: number;
+  isHovering?: boolean;
+  isStatic?: boolean;
+}) {
   return (
     <motion.div
-      className="fixed top-0 left-0 pointer-events-none z-50 flex items-center justify-center"
+      className="fixed top-0 left-0 pointer-events-none z-50"
       style={{ x, y, translateX: "-50%", translateY: "-50%" }}
     >
-      <div className="relative">
-        <motion.div
-          className="absolute inset-0 bg-blue-500/20 blur-xl rounded-full"
-          animate={{ scale: [1, 1.4, 1], opacity: [0.3, 0.6, 0.3] }}
-          transition={{ duration: 4, repeat: Infinity }}
-        />
-        <motion.svg
-          width="32"
-          height="32"
-          viewBox="0 0 24 24"
-          fill="none"
-          xmlns="http://www.w3.org/2000/svg"
-          animate={{ rotateY: 360 }}
-          transition={{ duration: 10, repeat: Infinity, ease: "linear" }}
-        >
-          <circle cx="12" cy="12" r="10" stroke="#3b82f6" strokeWidth="1.5" />
-          <path
-            d="M12 2C12 2 15 5 15 12C15 19 12 22 12 22C12 22 9 19 9 12C9 5 12 2 12 2Z"
-            stroke="#3b82f6"
-            strokeWidth="1"
+      {/* Atmosphere */}
+      <motion.div
+        className="absolute left-1/2 top-1/2 -translate-x-1/2 -translate-y-1/2 w-[52px] h-[52px] rounded-full"
+        style={{
+          background:
+            "radial-gradient(circle, rgba(59,130,246,0.3) 0%, transparent 70%)",
+          filter: "blur(6px)",
+        }}
+        animate={isStatic ? {} : { opacity: [0.6, 1, 0.6] }}
+        transition={{ duration: 3, repeat: Infinity, ease: "easeInOut" }}
+      />
+
+      <motion.div
+        animate={{ scale: isHovering ? 1.1 : 1 }}
+        transition={{ type: "spring", stiffness: 300, damping: 18 }}
+        style={{ filter: "drop-shadow(0 0 10px rgba(59,130,246,0.45))" }}
+      >
+        <svg width="34" height="34" viewBox="0 0 34 34">
+          <defs>
+            <radialGradient id="globeOcean" cx="36%" cy="32%" r="80%">
+              <stop offset="0%" stopColor="#7dd3fc" />
+              <stop offset="50%" stopColor="#3b82f6" />
+              <stop offset="100%" stopColor="#1e3a8a" />
+            </radialGradient>
+            <clipPath id="globeClip">
+              <circle cx="17" cy="17" r="13" />
+            </clipPath>
+          </defs>
+
+          {/* Ocean sphere */}
+          <circle cx="17" cy="17" r="13" fill="url(#globeOcean)" />
+
+          {/* Continents */}
+          <g clipPath="url(#globeClip)" fill="#34d399" opacity="0.9">
+            <path d="M8 11 C10 8.5 13.5 8.5 14.5 10.5 C15.5 12.4 13 13.5 13.8 15.5 C14.4 17 12.5 19.5 10.5 18.5 C8.5 17.5 6.5 13.5 8 11 Z" />
+            <path d="M20 9 C23 7.5 26.5 9 27 11.5 C27.4 13.6 24.5 14 24.8 16 C25 17.5 22 18.5 20.8 17 C19.6 15.5 18 10.5 20 9 Z" />
+            <path d="M19 22.5 C21 21.5 23.5 22.5 23.2 24.5 C22.9 26.3 19.8 27 18.5 25.8 C17.4 24.8 17.6 23.2 19 22.5 Z" />
+          </g>
+
+          {/* Graticule */}
+          <g
+            clipPath="url(#globeClip)"
+            stroke="#e0f2fe"
+            strokeWidth="0.5"
+            opacity="0.45"
+            fill="none"
+          >
+            <ellipse cx="17" cy="17" rx="13" ry="5.2" />
+            <ellipse cx="17" cy="17" rx="13" ry="9.6" opacity="0.6" />
+            <ellipse cx="17" cy="17" rx="5.2" ry="13" />
+          </g>
+
+          {/* Specular shine */}
+          <ellipse
+            cx="11.5"
+            cy="10.5"
+            rx="4.5"
+            ry="3"
+            fill="#ffffff"
+            opacity="0.35"
+            transform="rotate(-28 11.5 10.5)"
           />
-          <path d="M2.5 9H21.5" stroke="#3b82f6" strokeWidth="1" />
-          <path d="M2.5 15H21.5" stroke="#3b82f6" strokeWidth="1" />
-        </motion.svg>
-      </div>
+
+          {/* Rim */}
+          <circle
+            cx="17"
+            cy="17"
+            r="13"
+            fill="none"
+            stroke="#93c5fd"
+            strokeWidth="0.75"
+            opacity="0.8"
+          />
+        </svg>
+      </motion.div>
+
+      {/* Orbiting satellite */}
+      {!isStatic && (
+        <motion.div
+          className="absolute left-1/2 top-1/2"
+          animate={{ rotate: 360 }}
+          transition={{ duration: 6, repeat: Infinity, ease: "linear" }}
+        >
+          <div
+            className="w-1.5 h-1.5 rounded-full bg-slate-100 shadow-[0_0_5px_rgba(255,255,255,0.9)]"
+            style={{ transform: "translateX(21px)" }}
+          />
+        </motion.div>
+      )}
     </motion.div>
   );
 }

--- a/src/registry/cursors/cloud.tsx
+++ b/src/registry/cursors/cloud.tsx
@@ -1,22 +1,70 @@
 "use client";
+
 import { motion } from "framer-motion";
 
-export default function CloudCursor({ x, y }: { x: number; y: number }) {
+export default function CloudCursor({
+  x,
+  y,
+  isHovering,
+  isStatic,
+}: {
+  x: number;
+  y: number;
+  isHovering?: boolean;
+  isStatic?: boolean;
+}) {
   return (
     <motion.div
       className="fixed top-0 left-0 pointer-events-none z-50"
       style={{ x, y, translateX: "-50%", translateY: "-50%" }}
-      animate={{ y: [y - 2, y + 2, y - 2] }}
-      transition={{ duration: 2, repeat: Infinity, ease: "easeInOut" }}
     >
-      <svg width="32" height="20" viewBox="0 0 32 20">
-        <path
-          d="M8 18c-3.3 0-6-2.7-6-6s2.7-6 6-6c.5-3.4 3.4-6 7-6 3.9 0 7 3.1 7 7h1c2.8 0 5 2.2 5 5s-2.2 5-5 5H8z"
-          fill="white"
-          stroke="#94a3b8"
-          strokeWidth="1"
-        />
-      </svg>
+      <motion.div
+        animate={{
+          y: isStatic ? 0 : [0, -3, 0],
+          scale: isHovering ? 1.1 : 1,
+        }}
+        transition={{
+          y: { duration: 2.6, repeat: Infinity, ease: "easeInOut" },
+          scale: { type: "spring", stiffness: 300, damping: 18 },
+        }}
+        style={{ filter: "drop-shadow(0 2px 8px rgba(148,163,184,0.45))" }}
+      >
+        <svg width="36" height="26" viewBox="0 0 36 26">
+          <defs>
+            <linearGradient id="cloudBody" x1="0%" y1="0%" x2="0%" y2="100%">
+              <stop offset="0%" stopColor="#ffffff" />
+              <stop offset="70%" stopColor="#eef4fb" />
+              <stop offset="100%" stopColor="#cbdcee" />
+            </linearGradient>
+          </defs>
+
+          {/* Puffy silhouette */}
+          <path
+            d="M9 22 C5.7 22 3 19.3 3 16 C3 13 5.2 10.6 8.1 10.1 C9 6.4 12.2 3.5 16 3.5 C20.1 3.5 23.5 6.7 23.9 10.5 C26.9 10.8 29 13.2 29 16 C29 19.3 26.3 22 23 22 Z"
+            fill="url(#cloudBody)"
+            stroke="#b6c9dd"
+            strokeWidth="0.75"
+          />
+          {/* Bottom shading */}
+          <path
+            d="M5.5 19.5 C8 21 24 21 26.8 19"
+            stroke="#a8c0d8"
+            strokeWidth="1"
+            strokeLinecap="round"
+            fill="none"
+            opacity="0.55"
+          />
+          {/* Top highlight */}
+          <path
+            d="M10.5 9 C11.5 6.5 13.7 5 16.2 5"
+            stroke="#ffffff"
+            strokeWidth="1.4"
+            strokeLinecap="round"
+            fill="none"
+            opacity="0.9"
+          />
+        </svg>
+      </motion.div>
     </motion.div>
   );
 }

--- a/src/registry/cursors/feather.tsx
+++ b/src/registry/cursors/feather.tsx
@@ -1,0 +1,83 @@
+"use client";
+
+import { motion } from "framer-motion";
+
+export default function FeatherCursor({
+  x,
+  y,
+  isHovering,
+  isStatic,
+}: {
+  x: number;
+  y: number;
+  isHovering?: boolean;
+  isStatic?: boolean;
+}) {
+  return (
+    <motion.div
+      className="fixed top-0 left-0 pointer-events-none z-50"
+      style={{ x, y, translateX: "-50%", translateY: "-50%" }}
+    >
+      <motion.div
+        animate={{
+          rotate: isStatic ? -30 : [-34, -26, -34],
+          y: isStatic ? 0 : [0, -3, 0],
+          scale: isHovering ? 1.1 : 1,
+        }}
+        transition={{
+          rotate: { duration: 3.4, repeat: Infinity, ease: "easeInOut" },
+          y: { duration: 2.8, repeat: Infinity, ease: "easeInOut" },
+          scale: { type: "spring", stiffness: 300, damping: 18 },
+        }}
+        style={{ filter: "drop-shadow(0 2px 8px rgba(125,211,252,0.4))" }}
+      >
+        <svg width="22" height="34" viewBox="0 0 22 34">
+          <defs>
+            <linearGradient
+              id="featherVane"
+              x1="0%"
+              y1="0%"
+              x2="100%"
+              y2="100%"
+            >
+              <stop offset="0%" stopColor="#f0f9ff" />
+              <stop offset="55%" stopColor="#bae6fd" />
+              <stop offset="100%" stopColor="#7dd3fc" />
+            </linearGradient>
+          </defs>
+
+          {/* Vane */}
+          <path
+            d="M11 2 C17 5 19 12 16.5 19 C14.8 23.5 12 26 11 27 C10 26 7.2 23.5 5.5 19 C3 12 5 5 11 2 Z"
+            fill="url(#featherVane)"
+            stroke="#7dd3fc"
+            strokeWidth="0.6"
+          />
+          {/* Barb separations */}
+          <path
+            d="M11 6 L7 12 M11 10 L15.5 14 M11 14 L6.8 18 M11 18 L14.8 21"
+            stroke="#e0f2fe"
+            strokeWidth="0.7"
+            strokeLinecap="round"
+            opacity="0.8"
+          />
+          {/* Rachis (shaft) */}
+          <path
+            d="M11 2.5 C10.6 12 10.9 22 11.3 31.5"
+            stroke="#0ea5e9"
+            strokeWidth="1"
+            strokeLinecap="round"
+            fill="none"
+          />
+          {/* Quill tip */}
+          <path
+            d="M11.3 31.5 L11.6 33.5"
+            stroke="#e2e8f0"
+            strokeWidth="1.2"
+            strokeLinecap="round"
+          />
+        </svg>
+      </motion.div>
+    </motion.div>
+  );
+}

--- a/src/registry/cursors/index.ts
+++ b/src/registry/cursors/index.ts
@@ -37,6 +37,9 @@ import EclipseCursor from "./eclipse";
 import PotionCursor from "./potion";
 import RibbonCursor from "./ribbon";
 import PlasmaCursor from "./plasma";
+import StardustCursor from "./stardust";
+import FeatherCursor from "./feather";
+import BokehCursor from "./bokeh";
 
 // Minimal cursors
 import CircleCursor from "./circle";
@@ -434,6 +437,22 @@ export const CURSORS: CursorDefinition[] = [
     code: { react: `// Plasma cursor`, vanilla: `// Pending` },
   },
   {
+    id: "stardust",
+    name: "Stardust",
+    description: "Golden stars that tumble in your wake",
+    tags: ["effect", "particles", "magical"],
+    component: StardustCursor,
+    code: { react: `// Stardust cursor`, vanilla: `// Pending` },
+  },
+  {
+    id: "bokeh",
+    name: "Bokeh",
+    description: "Soft out-of-focus light orbs drifting behind",
+    tags: ["effect", "light", "calm"],
+    component: BokehCursor,
+    code: { react: `// Bokeh cursor`, vanilla: `// Pending` },
+  },
+  {
     id: "sakura",
     name: "Sakura",
     description: "Drifting cherry-blossom petals",
@@ -483,7 +502,7 @@ export const CURSORS: CursorDefinition[] = [
   {
     id: "moon",
     name: "Moon",
-    description: "Gentle swaying crescent",
+    description: "Cratered crescent with twinkling stars",
     tags: ["shape", "space"],
     component: MoonCursor,
     featured: true,
@@ -500,7 +519,7 @@ export const CURSORS: CursorDefinition[] = [
   {
     id: "cloud",
     name: "Cloud",
-    description: "Floating fluffy cloud",
+    description: "Soft drifting cumulus",
     tags: ["shape", "nature"],
     component: CloudCursor,
     code: { react: `// Cloud cursor`, vanilla: `// Pending` },
@@ -670,6 +689,14 @@ export const CURSORS: CursorDefinition[] = [
     tags: ["animated", "magical", "fun"],
     component: PotionCursor,
     code: { react: `// Potion cursor`, vanilla: `// Pending` },
+  },
+  {
+    id: "feather",
+    name: "Feather",
+    description: "Weightless quill drifting on air",
+    tags: ["animated", "calm", "elegant"],
+    component: FeatherCursor,
+    code: { react: `// Feather cursor`, vanilla: `// Pending` },
   },
 
   // === CREATIVE CATEGORY ===
@@ -940,7 +967,7 @@ export const CURSORS: CursorDefinition[] = [
   {
     id: "browser",
     name: "Globe",
-    description: "Spinning web globe",
+    description: "Blue marble with orbiting satellite",
     tags: ["animated", "tech"],
     component: BrowserCursor,
     code: { react: `// Browser cursor`, vanilla: `// Pending` },

--- a/src/registry/cursors/moon.tsx
+++ b/src/registry/cursors/moon.tsx
@@ -1,26 +1,97 @@
 "use client";
+
 import { motion } from "framer-motion";
 
-export default function MoonCursor({ x, y }: { x: number; y: number }) {
+export default function MoonCursor({
+  x,
+  y,
+  isHovering,
+  isStatic,
+}: {
+  x: number;
+  y: number;
+  isHovering?: boolean;
+  isStatic?: boolean;
+}) {
   return (
     <motion.div
       className="fixed top-0 left-0 pointer-events-none z-50"
       style={{ x, y, translateX: "-50%", translateY: "-50%" }}
-      animate={{ rotate: [0, 15, -15, 0] }}
-      transition={{ duration: 3, repeat: Infinity, ease: "easeInOut" }}
     >
-      <svg width="24" height="24" viewBox="0 0 24 24">
-        <path
-          d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z"
-          fill="url(#moonGrad)"
-        />
-        <defs>
-          <linearGradient id="moonGrad" x1="0%" y1="0%" x2="100%" y2="100%">
-            <stop offset="0%" stopColor="#fcd34d" />
-            <stop offset="100%" stopColor="#fbbf24" />
-          </linearGradient>
-        </defs>
-      </svg>
+      {/* Twinkling companions */}
+      {!isStatic && (
+        <>
+          <motion.div
+            className="absolute -left-4 -top-3"
+            animate={{ opacity: [0.2, 1, 0.2], scale: [0.7, 1, 0.7] }}
+            transition={{ duration: 2.2, repeat: Infinity }}
+          >
+            <svg width="8" height="8" viewBox="0 0 24 24">
+              <path
+                d="M12 0L14.5 9.5L24 12L14.5 14.5L12 24L9.5 14.5L0 12L9.5 9.5Z"
+                fill="#fde68a"
+              />
+            </svg>
+          </motion.div>
+          <motion.div
+            className="absolute -right-3 top-4"
+            animate={{ opacity: [1, 0.2, 1], scale: [1, 0.6, 1] }}
+            transition={{ duration: 2.8, repeat: Infinity, delay: 0.6 }}
+          >
+            <svg width="6" height="6" viewBox="0 0 24 24">
+              <path
+                d="M12 0L14.5 9.5L24 12L14.5 14.5L12 24L9.5 14.5L0 12L9.5 9.5Z"
+                fill="#fef3c7"
+              />
+            </svg>
+          </motion.div>
+        </>
+      )}
+
+      <motion.div
+        animate={{
+          rotate: isStatic ? 0 : [0, 8, -8, 0],
+          scale: isHovering ? 1.12 : 1,
+        }}
+        transition={{
+          rotate: { duration: 4, repeat: Infinity, ease: "easeInOut" },
+          scale: { type: "spring", stiffness: 300, damping: 18 },
+        }}
+        style={{ filter: "drop-shadow(0 0 10px rgba(251,191,36,0.55))" }}
+      >
+        <svg width="28" height="28" viewBox="0 0 28 28">
+          <defs>
+            <radialGradient id="moonGlowGrad" cx="38%" cy="35%" r="75%">
+              <stop offset="0%" stopColor="#fef9c3" />
+              <stop offset="55%" stopColor="#fde047" />
+              <stop offset="100%" stopColor="#f59e0b" />
+            </radialGradient>
+            <mask id="moonCrescent">
+              <rect width="28" height="28" fill="black" />
+              <circle cx="14" cy="14" r="11" fill="white" />
+              <circle cx="20.5" cy="9.5" r="9.5" fill="black" />
+            </mask>
+            <clipPath id="moonCrescentClip">
+              <path d="M14 3 A11 11 0 1 0 14 25 A11 11 0 0 0 20.5 9.5 A9.5 9.5 0 0 1 14 3 Z" />
+            </clipPath>
+          </defs>
+
+          {/* Crescent body */}
+          <rect
+            width="28"
+            height="28"
+            fill="url(#moonGlowGrad)"
+            mask="url(#moonCrescent)"
+          />
+
+          {/* Craters */}
+          <g clipPath="url(#moonCrescentClip)">
+            <circle cx="10" cy="15" r="1.8" fill="#d97706" opacity="0.4" />
+            <circle cx="13.5" cy="20" r="1.2" fill="#d97706" opacity="0.35" />
+            <circle cx="8.5" cy="10" r="1" fill="#d97706" opacity="0.3" />
+          </g>
+        </svg>
+      </motion.div>
     </motion.div>
   );
 }

--- a/src/registry/cursors/stardust.tsx
+++ b/src/registry/cursors/stardust.tsx
@@ -1,0 +1,84 @@
+"use client";
+
+import { motion } from "framer-motion";
+import { useEffect, useRef, useState } from "react";
+
+interface Star {
+  id: number;
+  x: number;
+  y: number;
+  size: number;
+  rotate: number;
+  drift: number;
+}
+
+export default function StardustCursor({
+  x,
+  y,
+  isStatic,
+}: {
+  x: number;
+  y: number;
+  isStatic?: boolean;
+}) {
+  const [stars, setStars] = useState<Star[]>([]);
+  const idRef = useRef(0);
+
+  useEffect(() => {
+    if (isStatic) return;
+    setStars((prev) => [
+      ...prev.slice(-7),
+      {
+        id: idRef.current++,
+        x: x + (Math.random() - 0.5) * 6,
+        y: y + (Math.random() - 0.5) * 6,
+        size: Math.random() * 5 + 4,
+        rotate: Math.random() * 90,
+        drift: (Math.random() - 0.5) * 16,
+      },
+    ]);
+  }, [x, y, isStatic]);
+
+  return (
+    <>
+      {/* Golden stars that tumble and fade */}
+      {stars.map((s) => (
+        <motion.div
+          key={s.id}
+          className="fixed top-0 left-0 pointer-events-none z-40"
+          style={{ x: s.x, y: s.y, translateX: "-50%", translateY: "-50%" }}
+          initial={{ opacity: 1, rotate: s.rotate, scale: 1 }}
+          animate={{
+            opacity: 0,
+            y: s.y + 20,
+            x: s.x + s.drift,
+            rotate: s.rotate + 120,
+            scale: 0.3,
+          }}
+          transition={{ duration: 0.8, ease: "easeOut" }}
+        >
+          <svg width={s.size} height={s.size} viewBox="0 0 24 24">
+            <path
+              d="M12 0L14.5 9.5L24 12L14.5 14.5L12 24L9.5 14.5L0 12L9.5 9.5Z"
+              fill="#fde68a"
+            />
+          </svg>
+        </motion.div>
+      ))}
+
+      {/* Radiant core */}
+      <motion.div
+        className="fixed top-0 left-0 w-3.5 h-3.5 rounded-full pointer-events-none z-50"
+        style={{
+          x,
+          y,
+          translateX: "-50%",
+          translateY: "-50%",
+          background: "radial-gradient(circle, #fffbeb 0%, #fbbf24 100%)",
+          boxShadow:
+            "0 0 14px rgba(251,191,36,0.9), 0 0 32px rgba(251,191,36,0.45)",
+        }}
+      />
+    </>
+  );
+}


### PR DESCRIPTION
## Summary

### Redesigned (flat → layered art)
- **Cloud** — gradient cumulus body, bottom shading, top highlight, soft shadow
- **Moon** — true crescent via SVG mask, radial gold gradient, craters, twinkling companion stars
- **Globe** — blue marble with ocean gradient, continents, graticule, specular shine, orbiting satellite

### New cursors (3)
- **Stardust** — golden stars tumbling in your wake
- **Feather** — weightless quill with gentle sway
- **Bokeh** — soft out-of-focus light orbs on lagging springs

Total: **104 cursors**

### Landing page
- Shimmer pill under the hero badge: '31 New Cursors Just Dropped' → /cursors
- Hero cursor stat now uses the live registry count (never stale)

### Verification
tsc clean, ESLint clean, 6/6 tests pass, production build succeeds, registry endpoints verified